### PR TITLE
Modify the SDATE_GFS conversion

### DIFF
--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -138,8 +138,8 @@ export precip1_mv_database_desc=${precip1_mv_database_desc:-"Precip METplus data
 echo
 
 # Check forecast max hours, adjust if before experiment SDATE_GFS
-export SDATE_GFS=${SDATE_GFS:-SDATE}
-SDATE_GFS_YYYYMMDDHH=$(echo $SDATE_GFS | cut -c1-10)
+SDATE_GFS=${SDATE_GFS:-SDATE}
+SDATE_GFS_YYYYMMDDHH=$(echo $SDATE_GFS | sed "s/-\|\:\| //g" | cut -c1-10)
 g2g1_anom_check_vhour="${g2g1_anom_vhr_list: -2}"
 g2g1_anom_fhr_max_idate="$($NDATE -${g2g1_anom_fhr_max} ${VDATE}${g2g1_anom_check_vhour})"
 if [ $g2g1_anom_fhr_max_idate -le $SDATE_GFS_YYYYMMDDHH ] ; then


### PR DESCRIPTION
Added a `sed` command to format the incoming `SDATE_GFS`.  This will work on both the old `SDATE` format of `YYYYMMDDHH` and the new `YYYY-MM-DD HH:MM:SS`.  Also, to prevent overwriting the existing `SDATE_GFS`, the `export` was removed.  Tested by running all three gfsmetp* jobs for one cycle.  Fixes #112 