### PR TITLE
Run metp jobs on the last cycle of CDATE

### DIFF
--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -37,8 +37,8 @@ if [[ ${SDATE_GFS} == "${CDATE}" && "${cyc}" != "00" ]]; then
         export vhr_list="${cyc}"
     elif [[ ${gfs_cyc} == 4 ]]; then
         # e.g. cyc=6, fcyc_list="6 12 18"
-        export fcyc_list="$(seq -f '%02g' ${cyc} 6 18)"
-        export vhr_list="$(seq -f '%02g' ${cyc} 6 18)"
+        export fcyc_list="$(seq -s ' ' -f '%02g' ${cyc} 6 18)"
+        export vhr_list="$(seq -s ' ' -f '%02g' ${cyc} 6 18)"
     fi
 fi
 
@@ -53,16 +53,16 @@ if [[ ${EDATE_GFS: -2} != "18" && ${VDATE} == ${EDATE_GFS:0:8} && ${gfs_cyc} != 
     fi
 
     if [[ ${gfs_cyc} == 2 ]]; then
-        export fcyc_list="$(seq -f '%02g' ${start_cycle} 12 ${last_cycle} )"
-        export vhr_list="$(seq -f '%02g' ${start_cycle} 12 ${last_cycle} )"
+        export fcyc_list="$(seq -s ' ' -f '%02g' ${start_cycle} 12 ${last_cycle} )"
+        export vhr_list="$(seq -s ' ' -f '%02g' ${start_cycle} 12 ${last_cycle} )"
     elif [[ ${gfs_cyc} == 4 ]]; then
-        export fcyc_list="$(seq -f '%02g' ${start_cycle}  6 ${last_cycle} )"
-        export vhr_list="$(seq -f '%02g' ${start_cycle}  6 ${last_cycle} )"
+        export fcyc_list="$(seq -s ' ' -f '%02g' ${start_cycle}  6 ${last_cycle} )"
+        export vhr_list="$(seq -s ' ' -f '%02g' ${start_cycle}  6 ${last_cycle} )"
     fi
 fi
 
 if [[ ${cyc2run} != ${cyc} ]]; then
-    echo "Skipping ${METPCASE} for ${cyc}"
+    echo "Skipping ${METPCASE} for cycle ${cyc}, will be run on cycle ${cyc2run}"
     exit 0
 fi
 

--- a/ush/set_init_valid_fhr_info.py
+++ b/ush/set_init_valid_fhr_info.py
@@ -29,10 +29,10 @@ def get_hr_list_info(hr_list):
     """
     hr_beg = (hr_list[0]).zfill(2)
     hr_end = (hr_list[-1]).zfill(2)
-    if len(hr_list) == 1:
+    if len(hr_list) <= 1:
         hr_inc = "86400"
     else:
-        hr_inc = str(3600 * int((int(hr_end) - int(hr_beg)) / len(hr_list)))
+        hr_inc = str(3600 * int((int(hr_end) - int(hr_beg)) / (len(hr_list)-1)))
 
     return hr_beg, hr_end, hr_inc
 

--- a/ush/set_init_valid_fhr_info.py
+++ b/ush/set_init_valid_fhr_info.py
@@ -52,12 +52,22 @@ def get_forecast_hours(fcyc_list, vhr_list, fhr_min_str, fhr_max_str):
     """
     fhr_min = float(fhr_min_str)
     fhr_max = float(fhr_max_str)
+    fcyc_list = [int(fcyc) for fcyc in fcyc_list]
+    vhr_list = [int(vhr) for vhr in vhr_list]
     nfcyc = len(fcyc_list)
     nvhr = len(vhr_list)
+    # Calculate the interval based on the forecast cycle or verification hour
+    # Assumes that the hours are evenly spaced (6,12,18 or 0, 12 or 6,9,12,15, but not 0,6,9)
     if nfcyc > nvhr:
-        fhr_intvl = int(24/nfcyc)
+        if nfcyc <= 1:
+            fhr_intvl = 24
+        else:
+            fhr_intvl = (max(fcyc_list) - min(fcyc_list)) / (len(fcyc_list) - 1)
     else:
-        fhr_intvl = int(24/nvhr)
+        if nvhr <= 1:
+            fhr_intvl = 24
+        else:
+            fhr_intvl = (max(vhr_list) - min(vhr_list)) / (len(vhr_list) - 1)
     nfhr = fhr_max/fhr_intvl
     fhr_max = int(nfhr*fhr_intvl)
     fhr_list = []

--- a/ush/set_init_valid_fhr_info.py
+++ b/ush/set_init_valid_fhr_info.py
@@ -29,7 +29,11 @@ def get_hr_list_info(hr_list):
     """
     hr_beg = (hr_list[0]).zfill(2)
     hr_end = (hr_list[-1]).zfill(2)
-    hr_inc = str(int((24/len(hr_list))*3600))
+    if len(hr_list) == 1:
+        hr_inc = "86400"
+    else:
+        hr_inc = str(3600 * int((int(hr_end) - int(hr_beg)) / len(hr_list)))
+
     return hr_beg, hr_end, hr_inc
 
 def get_forecast_hours(fcyc_list, vhr_list, fhr_min_str, fhr_max_str):


### PR DESCRIPTION
This modifies the metp jobs so they only run on the last GFS cycle of a given `CDATE`, i.e. 00Z when `gfs_cyc=1`, 12Z when `gfs_cyc=2`, or 18Z when `gfs_cyc=4`.

This also adds special cases for experiments that start/stop on the same `CDATE` and/or stop before the last GFS cycle of a given `CDATE`.  For example, if an experiment with `gfs_cyc=2`, `SDATE_GFS=2024010100`, and `EDATE_GFS=2024030100`, METplus jobs will run on `2024010112`, `2024010212`, and `2024010300` for cycles `[00, 12]`, `[00, 12]`, and `[00]`, respectively.

Refs noaa-emc/global-workflow#2790