### PR TITLE
Workaround: Sleep each METplus job by jobnum seconds to avoid race

### DIFF
--- a/ush/create_METplus_job_scripts.py
+++ b/ush/create_METplus_job_scripts.py
@@ -174,7 +174,7 @@ def create_job_scripts_step1(start_date_dt, end_date_dt, case, case_abbrev,
                 job_file = open(job_filename, 'w')
                 job_file.write('#!/bin/sh\n')
                 job_file.write('set -x\n')
-                job_file.write('\n')
+                job_file.write('\nsleep {:d}\n\n'.format(njob))
                 # Write environment variables
                 for name, value in job_env_dict.items():
                     job_file.write('export '+name+'="'+value+'"\n')


### PR DESCRIPTION
Fixes #132 

I'll be glad to get someone else's eyes on this.

Whether this is enough will depend on how long it takes the disk to read in METplus: there's enough caching that if the first process takes too much time the later ones might catch up, but we can tweak how long things sleep if that becomes an issue.