### PR TITLE
Revert #135: workaround for METplus<5 race condition

### DIFF
--- a/ush/create_METplus_job_scripts.py
+++ b/ush/create_METplus_job_scripts.py
@@ -174,7 +174,6 @@ def create_job_scripts_step1(start_date_dt, end_date_dt, case, case_abbrev,
                 job_file = open(job_filename, 'w')
                 job_file.write('#!/bin/sh\n')
                 job_file.write('set -x\n')
-                job_file.write('\nsleep {:d}\n\n'.format(njob))
                 # Write environment variables
                 for name, value in job_env_dict.items():
                     job_file.write('export '+name+'="'+value+'"\n')


### PR DESCRIPTION
PR #135 was a workaround for a race condition present in METplus<5 (discussed in #132).  My understanding is that [spack-stack 1.9.3 has METplus=6.0](https://github.com/JCSDA/spack-stack/blob/d0c3835d4167795feb8f02d024f736049a824ed1/configs/common/packages.yaml#L165-L172), which doesn't have that race condition, so the workaround is now redundant.

I have a vague memory of the one-second-delay workaround being insufficient in high load at some point, meaning global-workflow metp jobs went back to being serial to avoid crashes, but I can't find that discussion now.  The fix in METplus>=5 should be more general.  (EDIT: Found NOAA-EMC/global-workflow#2971)

On the other hand, a delay of seconds is not that much for jobs that take tens of minutes, so testing and merging this PR might be low on the priority list.  Any parallelization would still work without this PR.

This would clean up a bit of code made redundant as part of addressing issue #174