### PR TITLE
Allow gaps in time series where data is undefined 

### DIFF
--- a/ush/plotting_scripts/plot_time_series.py
+++ b/ush/plotting_scripts/plot_time_series.py
@@ -629,7 +629,6 @@ for plot_info in plot_info_list:
                 obs_plot_settings_dict = (
                     model_obs_plot_settings_dict['obs']
                 )
-
                 #### EMC-verif_global plot observations
                 if not obs_plotted:
                     if obs_count != 0:

--- a/ush/plotting_scripts/plot_time_series.py
+++ b/ush/plotting_scripts/plot_time_series.py
@@ -630,17 +630,6 @@ for plot_info in plot_info_list:
                     model_obs_plot_settings_dict['obs']
                 )
 
-                expected_interval = plot_util.infer_expected_interval(
-                    plot_time_dates,
-                    model_stat_values_array[0,:]
-                )
-
-                plot_time_dates_mc, model_stat_values_mc = plot_util.make_discontinuous(
-                    plot_time_dates,
-                    model_stat_values_array[0,:],
-                    expected_interval
-                )
-
                 #### EMC-verif_global plot observations
                 if not obs_plotted:
                     if obs_count != 0:
@@ -685,13 +674,19 @@ for plot_info in plot_info_list:
                 len(model_stat_values_array[0,:])
                 - np.ma.count_masked(model_stat_values_array[0,:])
             )
-            plot_time_dates_m = np.ma.masked_where(
-                np.ma.getmask(model_stat_values_array[0,:]), plot_time_dates
-            )
-            plot_time_dates_mc = np.ma.compressed(plot_time_dates_m)
-            model_stat_values_mc = np.ma.compressed(
+
+            expected_interval = plot_util.infer_expected_interval(
+                plot_time_dates,
                 model_stat_values_array[0,:]
             )
+
+            plot_time_dates_mc, model_stat_values_mc = plot_util.make_discontinuous(
+                plot_time_dates,
+                model_stat_values_array[0,:],
+                expected_interval
+            )
+
+
             #### EMC-verif_global plot model
             if count != 0:
                 logger.debug("Plotting model "+str(model_num)+" "

--- a/ush/plotting_scripts/plot_time_series.py
+++ b/ush/plotting_scripts/plot_time_series.py
@@ -629,6 +629,18 @@ for plot_info in plot_info_list:
                 obs_plot_settings_dict = (
                     model_obs_plot_settings_dict['obs']
                 )
+
+                expected_interval = plot_util.infer_expected_interval(
+                    plot_time_dates,
+                    model_stat_values_array[0,:]
+                )
+
+                plot_time_dates_mc, model_stat_values_mc = plot_util.make_discontinuous(
+                    plot_time_dates,
+                    model_stat_values_array[0,:],
+                    expected_interval
+                )
+
                 #### EMC-verif_global plot observations
                 if not obs_plotted:
                     if obs_count != 0:

--- a/ush/plotting_scripts/plot_util.py
+++ b/ush/plotting_scripts/plot_util.py
@@ -1080,7 +1080,7 @@ def make_discontinuous(time_array, data_array, expected_interval):
     """
     Insert NaNs only where actual valid data points are missing at the expected time interval.
     """
-    # Handle empty or single-element arrays
+    # return time_array and data_array as is if time_array is empty or only contains one element
     if len(time_array) <= 1:
         return np.asarray(time_array), np.asarray(data_array)
 
@@ -1132,7 +1132,7 @@ def infer_expected_interval(time_array, data_array):
         expected_interval = interval_counts.most_common(1)[0][0]
         return expected_interval
 
-    # Step 3: Fallback – calculate smallest interval in the raw time array
+    # Step 3: Fallback: calculate smallest interval in the raw time array
     time_diffs = np.diff(time_array)
 
     if len(time_diffs) == 0:

--- a/ush/plotting_scripts/plot_util.py
+++ b/ush/plotting_scripts/plot_util.py
@@ -4,6 +4,7 @@ import time
 import numpy as np
 import pandas as pd
 import warnings
+from collections import Counter
 warnings.filterwarnings('ignore')
 
 """!@namespace plot_util
@@ -1074,3 +1075,69 @@ def get_ci_file(stat, input_filename, fcst_lead, output_base_dir, ci_method):
     CI_file = os.path.join(output_base_dir, 'data',
                            CI_filename)
     return CI_file
+
+def make_discontinuous(time_array, data_array, expected_interval):
+    """
+    Insert NaNs only where actual valid data points are missing at the expected time interval.
+    """
+    # Handle empty or single-element arrays
+    if len(time_array) <= 1:
+        return np.asarray(time_array), np.asarray(data_array)
+
+    data_masked = np.ma.masked_invalid(data_array)
+    time_out = [time_array[0]]
+    data_out = [data_array[0]]
+
+    prev_idx = 0
+    for i in range(1, len(time_array)):
+        if not data_masked.mask[i]:
+            # check interval from previous valid point
+            if (time_array[i] - time_array[prev_idx]) != expected_interval:
+                time_out.append(np.nan)
+                data_out.append(np.nan)
+            time_out.append(time_array[i])
+            data_out.append(data_array[i])
+            prev_idx = i
+
+    return np.array(time_out), np.array(data_out)
+
+def infer_expected_interval(time_array, data_array):
+    """
+    Infer expected interval between meaningful data points even when
+    much of the data is undefined. Falls back to the minimum
+    time spacing in time_array if too few valid data points exist.
+    """
+
+    # convert time_array to a numpy array
+    time_array = np.asarray(time_array)
+
+    # Step 1: valid data_array indices (non-NaN points)
+    valid_idxs = np.where(~np.isnan(data_array))[0]
+
+    # Criteria for using valid data directly
+    # (1) need at least two points in data_array to form an interval
+    # (2) need at least 10% of data_array to be valid points
+    enough_valid = len(valid_idxs) >= 2
+    min_fraction_valid = 0.1
+    meets_fraction = (len(valid_idxs) / len(time_array)) >= min_fraction_valid if len(time_array) > 0 else False
+ 
+    # Step 2: compute intervals using valid points only
+    if enough_valid and meets_fraction:
+        # Calculate the intervals between consecutive valid data points
+        valid_intervals = np.diff(time_array[valid_idxs])
+
+        # Count how many times each interval occurs
+        interval_counts = Counter(valid_intervals)
+        # Select the most frequent interval
+        expected_interval = interval_counts.most_common(1)[0][0]
+        return expected_interval
+
+    # Step 3: Fallback – calculate smallest interval in the raw time array
+    time_diffs = np.diff(time_array)
+
+    if len(time_diffs) == 0:
+        # Time_array has 0 or 1 points, therefore no interval can be inferred
+        return 0
+
+    base_interval = np.min(time_diffs)
+    return base_interval

--- a/ush/plotting_scripts/plot_util.py
+++ b/ush/plotting_scripts/plot_util.py
@@ -1079,6 +1079,19 @@ def get_ci_file(stat, input_filename, fcst_lead, output_base_dir, ci_method):
 def make_discontinuous(time_array, data_array, expected_interval):
     """
     Insert NaNs only where actual valid data points are missing at the expected time interval.
+
+    Args:
+        time_array : array-like
+            Original time coordinates.
+        data_array : array-like
+            Original data values aligned with time_array.
+        expected_interval : float
+            Expected spacing between valid data points.
+
+    Returns:
+        time_out, data_out : np.ndarray
+            Arrays containing the original data and time points plus NaNs that represent
+            gaps due to undefined data.
     """
     # return time_array and data_array as is if time_array is empty or only contains one element
     if len(time_array) <= 1:
@@ -1106,6 +1119,16 @@ def infer_expected_interval(time_array, data_array):
     Infer expected interval between meaningful data points even when
     much of the data is undefined. Falls back to the minimum
     time spacing in time_array if too few valid data points exist.
+
+    Args:
+        time_array : array-like
+            Original time coordinates.
+        data_array : array-like
+            Original data values aligned with time_array.
+
+    Returns:
+        expected_interval : float
+            The inferred expected spacing between valid data points.
     """
 
     # convert time_array to a numpy array


### PR DESCRIPTION
**Description of Changes**

This PR adds support for plotting and processing time series that contain undefined data. The main enhancements involve detecting a data interval and inserting gaps only where data is actually undefined. This is accomplished by performing the following:  

1. Infer an expected time interval between valid data points. A helper function `infer_expected_interval` determines the expected time interval between valid data points. It identifies all valid (non-NaN) data points and selects the most common time interval among them. When too few valid points exist in a given time series, the function falls back to the minimum time interval in the original time_array. 

2.  Create discontinuous time and data arrays. A helper function `make_discontinuous` uses the inferred expected time interval calculated in the previous step and inserts gaps (represented by NaNs) only where valid data is actually undefined. 

This PR will remain in draft until preliminary testing is completed, sample plots have been generated, and helper function descriptions have been finalized. 

Addresses #183

**Developer Questions and Checklist**

Is this a high priority PR? If so, why and is there a date it needs to be merged by? No

Do you have any planned upcoming annual leave/PTO? Yes, I will be on leave 12/18-12/19. 

**Testing Instructions for Running  grid2grid, grid2obs and precip step 2 jobs on WCOSS2** 

git clone https://github.com/EricSinsky-NOAA/EMC_verif-global
cd EMC_verif-global/
git checkout issue183 (this branch is based on the develop branch, not the spack-stack 1.9.3 branch)
 vi parm/config/config.vrfy
```
export RUN_GRID2GRID_STEP1="NO"
export RUN_GRID2GRID_STEP2="YES"
export RUN_GRID2OBS_STEP1="NO"
export RUN_GRID2OBS_STEP2="YES"
export RUN_PRECIP_STEP1="NO"
export RUN_PRECIP_STEP2="YES"

export model_list="gfs retrov17_01_realtime"
export model_dir_list="/lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/global/archive/model_data /lfs/h2/emc/gfstemp/emc.global/archive"
export model_stat_dir_list="/lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/global/archive /lfs/h2/emc/gfstemp/emc.global/archive"
export model_file_format_list="pgbf{lead?fmt=%2H}.gfs.{init?fmt=%Y%m%d%H} pgbf{lead?fmt=%2H}.gfs.{init?fmt=%Y%m%d%H}.grib2"
export model_hpss_dir_list="/NCEPPROD/hpssprod/runhistory /NCEPPROD/hpssprod/runhistory"
export hpss_walltime="10 10"
export start_date=20251121
export end_date=20251214
export KEEPDATA="YES"
export OUTPUTROOT="/lfs/h2/emc/ptmp/$USER/verif_global_standalone_retrov17_01_step2_realtime"

export g2g2_model_plot_name_list="OPS RETRO"
export g2g2_anom_truth_name_list="self_anl self_anl"
export g2g2_anom_gather_by_list="VSDB VSDB"
export g2g2_pres_truth_name_list="self_anl self_anl"
export g2g2_pres_gather_by_list="VSDB VSDB"
export g2g2_sfc_truth_name_list="self_f00 self_f00"
export g2g2_sfc_gather_by_list="VSDB VSDB" 

export g2o2_model_plot_name_list="OPS RETRO"
export g2o2_upper_air_gather_by_list="VSDB VSDB"
export g2o2_conus_sfc_gather_by_list="VSDB VSDB"
export g2o2_polar_sfc_gather_by_list="VSDB VSDB"

export precip2_model_plot_name_list="OPS RETRO"
export precip2_ccpa_accum24hr_gather_by_list="VSDB VSDB"
```
cd ush/
./run_verif_global.sh ../parm/config/config.vrfy



