### PR TITLE
Feature/ss193 precip step2 add thesh by lead plot

### DIFF
--- a/parm/config/driver_standalone_step2_plots.sh
+++ b/parm/config/driver_standalone_step2_plots.sh
@@ -25,8 +25,8 @@ echo "BEGIN: $(basename ${BASH_SOURCE[0]})"
 #RUN_MAPS2D:          run to make forecast maps including lat-lon and zonal-mean distributions
 #RUN_MAPSDA:          run to make analysis maps of time-mean increments, ENKF ensemble mean and ensemble spread
 export RUN_GRID2GRID_STEP2="NO"
-export RUN_GRID2OBS_STEP2="YES"
-export RUN_PRECIP_STEP2="NO"
+export RUN_GRID2OBS_STEP2="NO"
+export RUN_PRECIP_STEP2="YES"
 export RUN_SATELLITE_STEP2="NO"
 export RUN_FIT2OBS_PLOTS="NO"
 export RUN_TROPCYC="NO"
@@ -57,8 +57,8 @@ export tar_archive_dir="/gpfs/f6/ira-sti/world-shared/$USER/KEEP_archive/tar_plo
 #spinup_period_end:   spinup period end, format YYYYMMDDHH, if none use "NA"
 #make_met_data_by:    how to treat dates, "VALID" or "INIT"
 #plot_by:             how to plot data, "VALID" or "INIT"
-export start_date=20241106
-export end_date=20241121
+export start_date=20241117
+export end_date=20241130
 export spinup_period_start="NA"
 export spinup_period_end="NA"
 export make_met_data_by="VALID"

--- a/ush/plots/precip/plot_lead_by_threshold.py
+++ b/ush/plots/precip/plot_lead_by_threshold.py
@@ -1,0 +1,658 @@
+'''
+Name: plot_lead_by_threshold.py
+Contact(s): Mallory Row (mallory.row@noaa.gov)
+Abstract: This script generates a lead by level plot.
+          (x-axis: forecast hour; y-axis: pressure levels; contours: statistics values)
+          (Graphics Naming Convention: vertprof_fhrmean)
+'''
+
+import sys
+import os
+import logging
+import datetime
+import glob
+import pandas as pd
+pd.plotting.deregister_matplotlib_converters()
+#pd.plotting.register_matplotlib_converters()
+import numpy as np
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import verif_global_util as vfg_util
+from precip_plots_specs import PlotSpecs
+
+class LeadByThreshold:
+    """
+    Make a lead by threshold graphic
+    """
+
+    def __init__(self, logger, input_dir, output_dir, model_info_dict,
+                 date_info_dict, plot_info_dict, met_info_dict, logo_dir):
+        """! Initialize LeadByThreshold class
+
+             Args:
+                 logger          - logger object
+                 input_dir       - path to input directory (string)
+                 output_dir      - path to output directory (string)
+                 model_info_dict - model infomation dictionary (strings)
+                 plot_info_dict  - plot information dictionary (strings)
+                 date_info_dict  - date information dictionary (strings)
+                 met_info_dict   - MET information dictionary (strings)
+                 logo_dir        - directory with logo images (string)
+
+             Returns:
+        """
+        self.logger = logger
+        self.input_dir = input_dir
+        self.output_dir = output_dir
+        self.model_info_dict = model_info_dict
+        self.date_info_dict = date_info_dict
+        self.plot_info_dict = plot_info_dict
+        self.met_info_dict = met_info_dict
+        self.logo_dir = logo_dir
+
+    def make_lead_by_threshold(self):
+        """! Make the lead by level graphic
+
+             Args:
+
+             Returns:
+        """
+        self.logger.info(f"Plot Type: Lead By Threshold...")
+        self.logger.debug(f"Input directory: {self.input_dir}")
+        self.logger.debug(f"Output directory: {self.output_dir}")
+        self.logger.debug(f"Model information dictionary: "
+                          +f"{self.model_info_dict}")
+        self.logger.debug(f"Date information dictionary: "
+                          +f"{self.date_info_dict}")
+        self.logger.debug(f"Plot information dictionary: "
+                          +f"{self.plot_info_dict}")
+        # Check stat
+        if self.plot_info_dict['stat'] == 'FBAR_OBAR':
+            self.logger.error("Cannot make lead_by_threshold for stat "
+                              +f"{self.plot_info_dict['stat']}")
+            sys.exit(1)
+        plot_specs_lbt = PlotSpecs(self.logger, 'lead_by_threshold')
+        self.logger.info(f"Building data for {self.plot_info_dict['stat']} "
+                         +"- lead by threshold ")
+        #                 +f"{self.plot_info_dict['vert_profile']}")
+        #vert_profile_levels = plot_specs_lbt.get_vert_profile_levels(
+        #    self.plot_info_dict['vert_profile']
+        #)
+        #if self.plot_info_dict['fcst_var_name'] == 'O3MR' and \
+        #        self.plot_info_dict['vert_profile'] == 'all':
+        #    vert_profile_levels = ['P100', 'P70', 'P50', 'P30', 'P20', 'P10', 'P5', 'P1']
+        #vert_profile_levels_int = np.empty(len(vert_profile_levels),
+        #                                   dtype=int)
+
+        fcst_var_threshs = self.plot_info_dict['fcst_var_threshs']
+        fcst_var_threshs_int = np.empty(len(fcst_var_threshs))
+        self.plot_info_dict['fcst_var_level'] = "A24"
+        self.plot_info_dict['obs_var_level'] = "A24"
+
+        #fcst_var_threshs_int = np.empty(len(fcst_var_threshs),
+        #                                    dtype=int)
+        #self.plot_info_dict['fcst_var_level'] = (
+        #    self.plot_info_dict['vert_profile']
+        #)
+        #self.plot_info_dict['obs_var_level'] = (
+        #    self.plot_info_dict['vert_profile']
+        #)
+        fcst_units = []
+        # Make dataframe for all levels and all forecast hours
+        for fcst_var_thresh in fcst_var_threshs:
+            self.logger.debug("Building data for forecast threshold "
+                              +f"{fcst_var_thresh}")
+            fcst_var_threshs_int[fcst_var_threshs.index(fcst_var_thresh)] = (
+                    fcst_var_thresh[2:]
+            )        
+            obs_var_thresh = fcst_var_thresh
+                              
+            for forecast_hour in self.date_info_dict['forecast_hours']:
+                self.logger.info(f"Building data for fcst_var_thresh {fcst_var_thresh} "
+                                 +f"forecast hour {forecast_hour}")
+                # Get dates to plot
+                self.logger.debug("Making valid and init date arrays")
+                valid_dates, init_dates = vfg_util.get_plot_dates(
+                    self.logger,
+                    self.date_info_dict['plot_by'],
+                    self.date_info_dict['start_date'],
+                    self.date_info_dict['end_date'],
+                    self.date_info_dict['valid_hr_start'],
+                    self.date_info_dict['valid_hr_end'],
+                    self.date_info_dict['valid_hr_inc'],
+                    self.date_info_dict['init_hr_start'],
+                    self.date_info_dict['init_hr_end'],
+                    self.date_info_dict['init_hr_inc'],
+                    forecast_hour
+                )
+                format_valid_dates = [
+                    valid_dates[d].strftime('%Y%m%d_%H%M%S') \
+                    for d in range(len(valid_dates))
+                ]
+                format_init_dates = [
+                    init_dates[d].strftime('%Y%m%d_%H%M%S') \
+                    for d in range(len(init_dates))
+                ]
+                if self.date_info_dict['plot_by'] == 'VALID':
+                    self.logger.debug("Based on date information, "
+                                      +"plot will display valid dates "
+                                      +', '.join(format_valid_dates)+" "
+                                      +"for forecast hour "
+                                      +f"{forecast_hour} with "
+                                      +"initialization dates "
+                                      +', '.join(format_init_dates))
+                    plot_dates = valid_dates
+                elif self.date_info_dict['plot_by'] == 'INIT':
+                    self.logger.debug("Based on date information, "
+                                      +"plot will display "
+                                      +"initialization dates "
+                                      +', '.join(format_init_dates)+" "
+                                      +"for forecast hour "
+                                      +f"{forecast_hour} with valid dates "
+                                      +', '.join(format_valid_dates))
+                    plot_dates = init_dates
+                # Read in data
+                all_model_df = vfg_util.build_df(
+                    'make_plots', self.logger, self.input_dir, self.output_dir,
+                    self.model_info_dict, self.met_info_dict,
+                    self.plot_info_dict['fcst_var_name'],
+                    self.plot_info_dict['fcst_var_level'],
+                    fcst_var_thresh,
+                    self.plot_info_dict['obs_var_name'],
+                    self.plot_info_dict['obs_var_level'],
+                    obs_var_thresh,
+                    self.plot_info_dict['line_type'],
+                    self.plot_info_dict['grid'],
+                    self.plot_info_dict['vx_mask'],
+                    self.plot_info_dict['interp_method'],
+                    self.plot_info_dict['interp_points'],
+                    self.date_info_dict['plot_by'],
+                    plot_dates, format_valid_dates,
+                    str(forecast_hour)
+                )
+                fcst_units.extend(
+                    all_model_df['FCST_UNITS'].values.astype('str')\
+                    .tolist()
+                )
+                # Calculate statistic mean
+                self.logger.info("Calculating statstic "
+                                 +f"{self.plot_info_dict['stat']} "
+                                 +"from line type "
+                                 +f"{self.plot_info_dict['line_type']} "
+                                 +"average")
+                stat_df, stat_array = vfg_util.calculate_stat(
+                    self.logger, all_model_df,
+                    self.plot_info_dict['line_type'],
+                    self.plot_info_dict['stat']
+                )
+                model_idx_list = (
+                    stat_df.index.get_level_values(0).unique().tolist()
+                )
+                if self.plot_info_dict['event_equalization'] == 'YES':
+                    self.logger.info("Doing event equalization")
+                    masked_stat_array = np.ma.masked_invalid(stat_array)
+                    stat_array = np.ma.mask_cols(masked_stat_array)
+                    stat_array = stat_array.filled(fill_value=np.nan)
+                    for model_idx in model_idx_list:
+                        model_idx_num = model_idx_list.index(model_idx)
+                        stat_df.loc[model_idx] = stat_array[model_idx_num,:]
+                        all_model_df.loc[model_idx] = (
+                            all_model_df.loc[model_idx].where(
+                                stat_df.loc[model_idx].notna()
+                        ).values)
+                if forecast_hour \
+                        == self.date_info_dict['forecast_hours'][0] \
+                        and fcst_var_thresh == fcst_var_threshs[0]:
+                    stat_forecast_hour_thresh_avg_df = pd.DataFrame(
+                        np.nan, pd.MultiIndex.from_product(
+                            [model_idx_list,
+                             self.date_info_dict['forecast_hours']],
+                            names=['model', 'fhr']
+                        ),
+                        columns=fcst_var_threshs
+                    )
+                for model_idx in model_idx_list:
+                    model_idx_num = model_idx_list.index(model_idx)
+                    if self.plot_info_dict['line_type'] in ['CNT', 'GRAD',
+                                                            'CTS',
+                                                            'NBRCTS',
+                                                            'NBRCNT',
+                                                            'VCNT']:
+                        avg_method = 'mean'
+                        calc_avg_df = stat_df.loc[model_idx]
+                    else:
+                        avg_method = 'aggregation'
+                        calc_avg_df = all_model_df.loc[model_idx]
+                    model_idx_forecast_hour_avg = vfg_util.calculate_average(
+                       self.logger, avg_method,
+                       self.plot_info_dict['line_type'],
+                       self.plot_info_dict['stat'], calc_avg_df
+                    )
+                    if not np.isnan(model_idx_forecast_hour_avg):
+                        stat_forecast_hour_thresh_avg_df.loc[
+                            (model_idx, forecast_hour), fcst_var_thresh
+                        ] = model_idx_forecast_hour_avg
+        # Set up plot
+        self.logger.info(f"Setting up plot")
+        plot_specs_lbt = PlotSpecs(self.logger, 'lead_by_threshold')
+        plot_specs_lbt.set_up_plot()
+        model_idx_list = (
+            stat_forecast_hour_thresh_avg_df.index\
+            .get_level_values(0).unique().tolist()
+        )
+        fhr_idx_list = (
+            stat_forecast_hour_thresh_avg_df.index\
+            .get_level_values(1).unique().tolist()
+        )
+        ymesh, xmesh = np.meshgrid(fcst_var_threshs_int, fhr_idx_list)
+        nsubplots = len(model_idx_list)
+        if nsubplots == 1:
+            gs_row, gs_col = 1, 1
+            gs_hspace, gs_wspace = 0, 0
+            gs_bottom, gs_top = 0.225, 0.85
+            cbar_bottom = 0.075
+            cbar_height = 0.02
+        elif nsubplots == 2:
+            gs_row, gs_col = 1, 2
+            gs_hspace, gs_wspace = 0, 0.1
+            gs_bottom, gs_top = 0.225, 0.85
+            cbar_bottom = 0.075
+            cbar_height = 0.02
+        elif nsubplots > 2 and nsubplots <= 4:
+            gs_row, gs_col = 2, 2
+            gs_hspace, gs_wspace = 0.15, 0.1
+            gs_bottom, gs_top = 0.125, 0.9
+            cbar_bottom = 0.04
+            cbar_height = 0.02
+        elif nsubplots > 4 and nsubplots <= 6:
+            gs_row, gs_col = 3, 2
+            gs_hspace, gs_wspace = 0.15, 0.1
+            gs_bottom, gs_top = 0.125, 0.9
+            cbar_bottom = 0.04
+            cbar_height = 0.02
+        elif nsubplots > 6 and nsubplots <= 8:
+            gs_row, gs_col = 4, 2
+            gs_hspace, gs_wspace = 0.175, 0.1
+            gs_bottom, gs_top = 0.125, 0.9
+            cbar_bottom = 0.04
+            cbar_height = 0.02
+        elif nsubplots > 8 and nsubplots <= 10:
+            gs_row, gs_col = 5, 2
+            gs_hspace, gs_wspace = 0.225, 0.1
+            gs_bottom, gs_top = 0.125, 0.9
+            cbar_bottom = 0.04
+            cbar_height = 0.02
+        else:
+            self.logger.error("Too many subplots requested, maximum is 10")
+            sys.exit(1)
+        if nsubplots <= 2:
+            plot_specs_lbt.fig_size = (16., 8.)
+            plot_specs_lbt.fig_title_size = 16
+            plt.rcParams['figure.titlesize'] = plot_specs_lbt.fig_title_size
+        if nsubplots >= 2:
+            n_xticks = 8
+        else:
+            n_xticks = 17
+        if len(self.date_info_dict['forecast_hours']) <= n_xticks:
+            xticks = self.date_info_dict['forecast_hours']
+        else:
+            xticks = []
+            for fhr in self.date_info_dict['forecast_hours']:
+                if int(fhr) % 24 == 0:
+                    xticks.append(fhr)
+            if len(xticks) > n_xticks:
+                xtick_intvl = int(len(xticks)/n_xticks)
+                xticks = xticks[::xtick_intvl]
+        fcst_var_threshs_int_ticks =fcst_var_threshs_int
+        fcst_units = np.unique(fcst_units)
+        fcst_units = np.delete(fcst_units, np.where(fcst_units == 'nan'))
+        if len(fcst_units) > 1:
+            self.logger.error(f"Have multilple units: {', '.join(fcst_units)}")
+            sys.exit(1)
+        elif len(fcst_units) == 0:
+            self.logger.debug("Cannot get variables units, leaving blank")
+            fcst_units = ['']
+        plot_title = plot_specs_lbt.get_plot_title(
+            self.plot_info_dict, self.date_info_dict,
+            fcst_units[0]
+        )
+        plot_left_logo_path = os.path.join(self.logo_dir, 'noaa.png')
+        if os.path.exists(plot_left_logo_path):
+            plot_left_logo = True
+            left_logo_img_array = matplotlib.image.imread(
+                plot_left_logo_path
+            )
+            left_logo_xpixel_loc, left_logo_ypixel_loc, left_logo_alpha = (
+                plot_specs_lbt.get_logo_location(
+                    'left', plot_specs_lbt.fig_size[0],
+                    plot_specs_lbt.fig_size[1], plt.rcParams['figure.dpi']
+                )
+            )
+        else:
+            plot_left_logo = False
+            self.logger.debug(f"{plot_left_logo_path} does not exist")
+        plot_right_logo_path = os.path.join(self.logo_dir, 'nws.png')
+        if os.path.exists(plot_right_logo_path):
+            plot_right_logo = True
+            right_logo_img_array = matplotlib.image.imread(
+                 plot_right_logo_path
+            )
+            right_logo_xpixel_loc, right_logo_ypixel_loc, right_logo_alpha = (
+                plot_specs_lbt.get_logo_location(
+                    'right', plot_specs_lbt.fig_size[0],
+                    plot_specs_lbt.fig_size[1], plt.rcParams['figure.dpi']
+                )
+            )
+        else:
+            plot_right_logo = False
+            self.logger.debug(f"{plot_right_logo_path} does not exist")
+        image_name = plot_specs_lbt.get_savefig_name(
+            self.output_dir, self.plot_info_dict, self.date_info_dict
+        )
+        subplot0_cmap, subplotsN_cmap = plot_specs_lbt.get_plot_colormaps(
+            self.plot_info_dict['stat']
+        )
+        subplot0_data = (
+            stat_forecast_hour_thresh_avg_df.loc[
+                model_idx_list[0]
+            ].values
+        )
+        for model_idx in model_idx_list[1:]:
+            subplotN_data = (
+                stat_forecast_hour_thresh_avg_df.loc[
+                    model_idx
+                ].values
+            )
+            if model_idx == model_idx_list[1]:
+                subplotsN_data = [subplotN_data]
+            else:
+                subplotsN_data = np.concatenate((subplotsN_data,
+                                                 [subplotN_data]))
+        if len(model_idx_list) == 1:
+            subplotsN_data = [np.nan]
+        (have_subplot0_levs, subplot0_levs,
+         have_subplotsN_levs, subplotsN_levs) = (
+            plot_specs_lbt.get_plot_contour_levels(
+                self.plot_info_dict['stat'], subplot0_data, subplotsN_data
+            )
+        )
+        make_colorbar = False
+        #################################################
+        # Make plot  
+        #################################################
+        self.logger.info(f"Making plot ...............")
+        fig = plt.figure(figsize=(plot_specs_lbt.fig_size[0],
+                                  plot_specs_lbt.fig_size[1]))
+        gs = gridspec.GridSpec(gs_row, gs_col,
+                               bottom=gs_bottom, top=gs_top,
+                               hspace=gs_hspace, wspace=gs_wspace)
+        fig.suptitle(plot_title)
+        if plot_left_logo:
+            left_logo_img = fig.figimage(
+                left_logo_img_array,
+                left_logo_xpixel_loc - (left_logo_xpixel_loc * 0.5),
+                left_logo_ypixel_loc, zorder=1, alpha=right_logo_alpha
+            )
+            left_logo_img.set_visible(True)
+        if plot_right_logo:
+            right_logo_img = fig.figimage(
+                right_logo_img_array, right_logo_xpixel_loc,
+                right_logo_ypixel_loc, zorder=1, alpha=right_logo_alpha
+            )
+        for model_idx in model_idx_list:
+            model_num = model_idx.split('/')[0]
+            model_num_name = model_idx.split('/')[1]
+            model_num_plot_name = model_idx.split('/')[2]
+            model_num_obs_name = (
+                self.model_info_dict[model_num]['obs_name']
+            )
+            model_num_data = stat_forecast_hour_thresh_avg_df.loc[
+                model_idx
+            ].values
+            masked_model_num_data = np.ma.masked_invalid(model_num_data)
+            ax = plt.subplot(gs[model_idx_list.index(model_idx)])
+            ax.grid(True)
+            ax.set_xlim([self.date_info_dict['forecast_hours'][0],
+                         self.date_info_dict['forecast_hours'][-1]])
+            ax.set_xticks(xticks)
+            if ax.get_subplotspec().is_last_row() \
+                    or (nsubplots % 2 != 0 \
+                        and model_idx_list.index(model_idx) \
+                        == nsubplots-1):
+                ax.set_xlabel('Forecast Hour')
+            else:
+                plt.setp(ax.get_xticklabels(), visible=False)
+            ax.set_yscale('log')
+            ax.minorticks_off()
+            ax.set_yticks(fcst_var_threshs_int_ticks)
+            ax.set_yticklabels(fcst_var_threshs_int_ticks)
+            ax.set_ylim([fcst_var_threshs_int[0],
+                         fcst_var_threshs_int[-1]])
+            if ax.get_subplotspec().is_first_col() \
+                    or (nsubplots % 2 != 0 \
+                        and model_idx_list.index(model_idx) \
+                        == nsubplots -1):
+                ax.set_ylabel('Thresholds (kg/m^2)')
+            else:
+                plt.setp(ax.get_yticklabels(), visible=False)
+
+            #First sub-plot: 
+            if model_idx == model_idx_list[0]:
+                self.logger.debug(f"Plotting {model_num} ["
+                                  +f"{model_num_name},"
+                                  +f"{model_num_plot_name}]")
+                ax.set_title(model_num_plot_name)
+                subplot_name = model_num_name
+                subplot0_plot_name = model_num_plot_name
+                subplot0_data = masked_model_num_data
+                if not subplot0_data.mask.all():
+                    if have_subplot0_levs:
+                        CF0 = ax.contourf(xmesh, ymesh, subplot0_data,
+                                          levels=subplot0_levs,
+                                          cmap=subplot0_cmap,
+                                          extend='both')
+                    else:
+                        CF0 = ax.contourf(xmesh, ymesh, subplot0_data,
+                                          cmap=subplot0_cmap,
+                                          extend='both')
+                    C0 = ax.contour(xmesh, ymesh, subplot0_data,
+                                    levels=CF0.levels, colors='k',
+                                    linewidths=1.0)
+                    C0_labels_list = []
+                    for lev in C0.levels:
+                        if str(lev).split('.')[1] == '0':
+                            C0_labels_list.append(str(int(lev)))
+                        else:
+                            C0_labels_list.append(
+                                str(round(lev,3)).rstrip('0')
+                            )
+                    C0_fmt = {}
+                    for lev, label in zip(C0.levels, C0_labels_list):
+                        C0_fmt[lev] = label
+                    ax.clabel(C0, C0.levels, fmt=C0_fmt, inline=True,
+                              fontsize=12.5)
+                    if self.plot_info_dict['stat'] in ['BIAS', 'ME', 'FBIAS', 'ETS']:
+                        if not make_colorbar:
+                            make_colorbar = True
+                            cbar_CF = CF0
+                            cbar_ticks = CF0.levels
+                            cbar_label = plot_specs_lbt.get_stat_plot_name(
+                                self.plot_info_dict['stat']
+                            )
+                else:
+                    self.logger.debug(f"{model_num} [{model_num_name},"
+                                      +f"{model_num_plot_name}] is fully "
+                                      +"masked")
+            else:
+                #Other sub-plots
+                if self.plot_info_dict['stat'] in ['BIAS', 'ME', 'FBIAS', 'ETS']:
+                    self.logger.debug(f"Plotting {model_num} ["
+                                      +f"{model_num_name},"
+                                      +f"{model_num_plot_name}]")
+                    ax.set_title(model_num_plot_name)
+                    subplotN_data = masked_model_num_data
+                #Other sub-plots but for difference    
+                else:
+                    self.logger.debug(f"Plotting {model_num} ["
+                                      +f"{model_num_name},"
+                                      +f"{model_num_plot_name}] "
+                                      +"difference from model1 ["
+                                      +f"{subplot_name},"
+                                      +f"{subplot0_plot_name}]")
+                    ax.set_title(model_num_plot_name+'-'+subplot0_plot_name)
+                    subplotN_data = masked_model_num_data - subplot0_data
+                if not subplotN_data.mask.all():
+                    if have_subplotsN_levs:
+                        CFN = ax.contourf(xmesh, ymesh, subplotN_data,
+                                          levels=subplotsN_levs,
+                                          cmap=subplotsN_cmap,
+                                          extend='both')
+                        if self.plot_info_dict['stat'] in ['BIAS', 'ME',
+                                                           'FBIAS', 'ETS']:
+                            CN = ax.contour(xmesh, ymesh, subplotN_data,
+                                            levels=CFN.levels, colors='k',
+                                            linewidths=1.0)
+                            CN_labels_list = []
+                            for lev in CN.levels:
+                                if str(lev).split('.')[1] == '0':
+                                    CN_labels_list.append(str(int(lev)))
+                                else:
+                                    CN_labels_list.append(
+                                        str(round(lev,3)).rstrip('0')
+                                    )
+                            CN_fmt = {}
+                            for lev, label in zip(CN.levels,
+                                                  CN_labels_list):
+                                CN_fmt[lev] = label
+                            ax.clabel(CN, CN.levels,
+                                      fmt=CN_fmt, inline=True,
+                                      fontsize=12.5)
+                        if not make_colorbar:
+                            make_colorbar = True
+                            cbar_CF = CFN
+                            cbar_ticks = CFN.levels
+                            if self.plot_info_dict['stat'] in ['BIAS', 'ME',
+                                                               'FBIAS', 'ETS']:
+                                cbar_label = (
+                                    plot_specs_lbt.get_stat_plot_name(
+                                        self.plot_info_dict['stat']
+                                    )
+                                )
+                            else:
+                                cbar_label = 'Difference'
+                    else:
+                        self.logger.debug("Do not have contour levels "
+                                          +"to plot")
+                else:
+                    if self.plot_info_dict['stat'] in ['BIAS', 'ME', 'FBIAS', 'ETS']:
+                        self.logger.debug(f"{model_num} ["
+                                          +f"{model_num_name},"
+                                          +f"{model_num_plot_name}] is fully "
+                                          +"masked")
+                    else:
+                        self.logger.debug(f"{model_num} ["
+                                          +f"{model_num_name},"
+                                          +f"{model_num_plot_name}] "
+                                          +"difference from model1 ["
+                                          +f"{subplot_name},"
+                                          +f"{subplot0_plot_name}] is fully "
+                                          +"masked")
+        if make_colorbar:
+            cbar_left = gs.get_grid_positions(fig)[2][0]
+            cbar_width = (gs.get_grid_positions(fig)[3][-1]
+                          - gs.get_grid_positions(fig)[2][0])
+            cbar_ax = fig.add_axes(
+                [cbar_left, cbar_bottom, cbar_width, cbar_height]
+            )
+            cbar = fig.colorbar(cbar_CF, cax=cbar_ax,
+                                orientation='horizontal',
+                                ticks=cbar_ticks)
+            cbar.ax.set_xlabel(cbar_label, labelpad = 0)
+            cbar.ax.xaxis.set_tick_params(pad=0)
+            cbar_tick_labels_list = []
+            for tick in cbar.get_ticks():
+                if str(tick).split('.')[1] == '0':
+                    cbar_tick_labels_list.append(
+                        str(int(tick))
+                    )
+                else:
+                    cbar_tick_labels_list.append(
+                        str(round(tick,3)).rstrip('0')
+                    )
+            cbar.ax.set_xticklabels(cbar_tick_labels_list)
+        self.logger.info("Saving image as "+image_name)
+        plt.savefig(image_name)
+        plt.clf()
+        plt.close('all')
+
+def main():
+    # Need settings
+    INPUT_DIR = os.environ['HOME']
+    OUTPUT_DIR = os.environ['HOME']
+    LOGO_DIR = os.environ['HOME']
+    MODEL_INFO_DICT = {
+        'model1': {'name': 'MODEL_A',
+                   'plot_name': 'PLOT_MODEL_A',
+                   'obs_name': 'MODEL_A_OBS'},
+    }
+    DATE_INFO_DICT = {
+        'plot_by': 'DATE_TYPE',
+        'start_date': 'START_DATE',
+        'end_date': 'END_DATE',
+        'valid_hr_start': 'VALID_HR_START',
+        'valid_hr_end': 'VALID_HR_END',
+        'valid_hr_inc': 'VALID_HR_INC',
+        'init_hr_start': 'INIT_HR_START',
+        'init_hr_end': 'INIT_HR_END',
+        'init_hr_inc': 'INIT_HR_INC',
+        'forecast_hour': ['FORECAST_HOURS']
+    }
+    PLOT_INFO_DICT = {
+        'line_type': 'LINE_TYPE',
+        'grid': 'GRID',
+        'stat': 'STAT',
+        'vx_mask': 'VX_MASK',
+        'event_equalization': 'EVENT_EQUALIZATION',
+        'interp_method': 'INTERP_METHOD',
+        'interp_points': 'INTERP_POINTS',
+        'fcst_var_name': 'FCST_VAR_NAME',
+        'fcst_var_level': 'FCST_VAR_LEVEL',
+        'fcst_var_threshs': 'FCST_VAR_THRESHS',
+        'obs_var_name': 'OBS_VAR_NAME',
+        'obs_var_level': 'OBS_VAR_LEVEL',
+        'obs_var_threshs': 'OBS_VAR_THRESHS'
+    }
+    MET_INFO_DICT = {
+        'root': '/PATH/TO/MET',
+        'version': '12.0'
+    }
+    # Make OUTPUT_DIR
+    vfg_util.make_dir(OUTPUT_DIR)
+    # Set up logging
+    logging_dir = os.path.join(OUTPUT_DIR, 'logs')
+    vfg_util.make_dir(logging_dir)
+    job_logging_file = os.path.join(logging_dir,
+                                    os.path.basename(__file__)+'_runon'
+                                    +datetime.datetime.now()\
+                                    .strftime('%Y%m%d%H%M%S')+'.log')
+    logger = logging.getLogger(job_logging_file)
+    logger.setLevel('DEBUG')
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(job_logging_file, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {job_logging_file}"
+    print(logger_info)
+    logger.info(logger_info)
+    p = LeadByThreshold(logger, INPUT_DIR, OUTPUT_DIR, MODEL_INFO_DICT,
+                    DATE_INFO_DICT, PLOT_INFO_DICT, MET_INFO_DICT, LOGO_DIR)
+    p.make_lead_by_threshold()
+
+if __name__ == "__main__":
+    main()

--- a/ush/plots/precip/plot_time_series.py
+++ b/ush/plots/precip/plot_time_series.py
@@ -390,9 +390,7 @@ class TimeSeries:
                             round(obar_model_num_avg, 3), '.3f'
                         )
                 ax.plot_date(
-                    #np.ma.compressed(masked_plot_dates),
                     masked_plot_dates,
-                    #np.ma.compressed(masked_model_num_data),
                     masked_model_num_data,
                     fmt=model_num_plot_settings_dict['marker'],
                     color = model_num_plot_settings_dict['color'],

--- a/ush/plots/precip/plot_time_series.py
+++ b/ush/plots/precip/plot_time_series.py
@@ -390,8 +390,10 @@ class TimeSeries:
                             round(obar_model_num_avg, 3), '.3f'
                         )
                 ax.plot_date(
-                    np.ma.compressed(masked_plot_dates),
-                    np.ma.compressed(masked_model_num_data),
+                    #np.ma.compressed(masked_plot_dates),
+                    masked_plot_dates,
+                    #np.ma.compressed(masked_model_num_data),
+                    masked_model_num_data,
                     fmt=model_num_plot_settings_dict['marker'],
                     color = model_num_plot_settings_dict['color'],
                     linestyle = model_num_plot_settings_dict['linestyle'],
@@ -417,8 +419,8 @@ class TimeSeries:
                             model_plot_settings_dict['obs']
                         )
                         ax.plot_date(
-                            np.ma.compressed(obar_masked_plot_dates),
-                            np.ma.compressed(obar_masked_model_num_data),
+                            obar_masked_plot_dates,
+                            obar_masked_model_num_data,
                             fmt = obs_plot_settings_dict['marker'],
                             color = obs_plot_settings_dict['color'],
                             linestyle = obs_plot_settings_dict['linestyle'],

--- a/ush/plots/precip/precip_plots.py
+++ b/ush/plots/precip/precip_plots.py
@@ -439,7 +439,6 @@ elif JOB_GROUP == 'make_plots':
                                                        met_info_dict,
                                                        logo_dir)
                     plot_ta.make_threshold_average()
-    #Binbin: This part needs to work
     elif plot == 'lead_by_threshold':
         import plot_lead_by_threshold as p_lbt
         for lbt_info in list(itertools.product(valid_hrs, var_info)):

--- a/ush/plots/precip/precip_plots.py
+++ b/ush/plots/precip/precip_plots.py
@@ -439,57 +439,21 @@ elif JOB_GROUP == 'make_plots':
                                                        met_info_dict,
                                                        logo_dir)
                     plot_ta.make_threshold_average()
-    elif plot == 'lead_by_date':
-        import plot_lead_by_date as p_lbd
-        for lbd_info in list(itertools.product(valid_hrs, var_info)):
-            date_info_dict['valid_hr_start'] = str(lbd_info[0])
-            date_info_dict['valid_hr_end'] = str(lbd_info[0])
+    #Binbin: This part needs to work
+    elif plot == 'lead_by_threshold':
+        import plot_lead_by_threshold as p_lbt
+        for lbt_info in list(itertools.product(valid_hrs, var_info)):
+            date_info_dict['valid_hr_start'] = str(lbt_info[0])
+            date_info_dict['valid_hr_end'] = str(lbt_info[0])
             date_info_dict['valid_hr_inc'] = '24'
             date_info_dict['forecast_hours'] = fhrs
-            plot_info_dict['fcst_var_name'] = lbd_info[1][0][0]
-            plot_info_dict['fcst_var_level'] = lbd_info[1][0][1]
-            plot_info_dict['fcst_var_thresh'] = lbd_info[1][0][2]
-            plot_info_dict['obs_var_name'] = lbd_info[1][1][0]
-            plot_info_dict['obs_var_level'] = lbd_info[1][1][1]
-            plot_info_dict['obs_var_thresh'] = lbd_info[1][1][2]
-            job_DATA_image_name = plot_specs.get_savefig_name(
-                job_DATA_dir, plot_info_dict, date_info_dict
-            )
-            job_input_dir = make_plots_input_dir
-            if not os.path.exists(job_DATA_image_name) \
-                    and plot_info_dict['stat'] != 'FBAR_OBAR':
-                if len(date_info_dict['forecast_hours']) <= 1:
-                    logger.warning("No span of forecast hours to plot, "
-                                   +"given 1 forecast hour, skipping "
-                                   +"lead_by_date plots")
-                    make_lbd = False
-                else:
-                    make_lbd = True
-            else:
-                make_lbd = False
-            if make_lbd:
-                plot_lbd = p_lbd.LeadByDate(logger, job_input_dir,
-                                            job_DATA_dir, model_info_dict,
-                                            date_info_dict, plot_info_dict,
-                                            met_info_dict, logo_dir)
-                plot_lbd.make_lead_by_date()
-    elif plot == 'lead_by_level':
-        import plot_lead_by_level as p_lbl
-        fhrs_lbl = fhrs
-        vert_profiles = [os.environ['vert_profile']]
-        for lbl_info in list(itertools.product(valid_hrs, vert_profiles)):
-            date_info_dict['valid_hr_start'] = str(lbl_info[0])
-            date_info_dict['valid_hr_end'] = str(lbl_info[0])
-            date_info_dict['valid_hr_inc'] = '24'
-            date_info_dict['forecast_hours'] = fhrs_lbl
+            plot_info_dict['fcst_var_threshs'] = fcst_var_thresh_list
+            plot_info_dict['obs_var_threshs'] = obs_var_thresh_list
             plot_info_dict['fcst_var_name'] = fcst_var_name
             plot_info_dict['obs_var_name'] = obs_var_name
-            plot_info_dict['vert_profile'] = lbl_info[1]
-            plot_info_dict['fcst_var_level'] = lbl_info[1]
-            plot_info_dict['obs_var_level'] = lbl_info[1]
-            for t in range(len(fcst_var_thresh_list)):
-                plot_info_dict['fcst_var_thresh'] = fcst_var_thresh_list[t]
-                plot_info_dict['obs_var_thresh'] = obs_var_thresh_list[t]
+            for l in range(len(fcst_var_level_list)):
+                plot_info_dict['fcst_var_level'] = fcst_var_level_list[l]
+                plot_info_dict['obs_var_level'] = obs_var_level_list[l]
                 job_DATA_image_name = plot_specs.get_savefig_name(
                     job_DATA_dir, plot_info_dict, date_info_dict
                 )
@@ -499,59 +463,23 @@ elif JOB_GROUP == 'make_plots':
                     if len(date_info_dict['forecast_hours']) <= 1:
                         logger.warning("No span of forecast hours to plot, "
                                        +"given 1 forecast hour, skipping "
-                                       +"lead_by_level plots")
-                        make_lbl = False
+                                       +"lead_by_threshold plots")
+                        make_lbt = False
                     else:
-                        make_lbl = True
+                        make_lbt = True
                 else:
-                    make_lbl = False
+                    make_lbt = False
                 del plot_info_dict['fcst_var_level']
                 del plot_info_dict['obs_var_level']
-                if make_lbl:
-                    plot_lbl = p_lbl.LeadByLevel(logger,
+                if make_lbt:
+                    plot_lbt = p_lbt.LeadByThreshold(logger,
                                                  job_input_dir,
                                                  job_DATA_dir,
                                                  model_info_dict,
                                                  date_info_dict,
                                                  plot_info_dict,
                                                  met_info_dict, logo_dir)
-                    plot_lbl.make_lead_by_level()
-    elif plot == 'date_by_level':
-        import plot_date_by_level as p_dbl
-        vert_profiles = [os.environ['vert_profile']]
-        for dbl_info in list(itertools.product(valid_hrs, fhrs, vert_profiles)):
-            date_info_dict['valid_hr_start'] = str(dbl_info[0])
-            date_info_dict['valid_hr_end'] = str(dbl_info[0])
-            date_info_dict['valid_hr_inc'] = '24'
-            date_info_dict['forecast_hour'] = str(dbl_info[1])
-            plot_info_dict['fcst_var_name'] = fcst_var_name
-            plot_info_dict['obs_var_name'] = obs_var_name
-            plot_info_dict['vert_profile'] = dbl_info[2]
-            plot_info_dict['fcst_var_level'] = dbl_info[2]
-            plot_info_dict['obs_var_level'] = dbl_info[2]
-            for t in range(len(fcst_var_thresh_list)):
-                plot_info_dict['fcst_var_thresh'] = fcst_var_thresh_list[t]
-                plot_info_dict['obs_var_thresh'] = obs_var_thresh_list[t]
-                job_DATA_image_name = plot_specs.get_savefig_name(
-                    job_DATA_dir, plot_info_dict, date_info_dict
-                )
-                job_input_dir = make_plots_input_dir
-                if not os.path.exists(job_DATA_image_name) \
-                        and plot_info_dict['stat'] != 'FBAR_OBAR':
-                    make_dbl = True
-                else:
-                    make_dbl = False
-                del plot_info_dict['fcst_var_level']
-                del plot_info_dict['obs_var_level']
-                if make_dbl:
-                    plot_dbl = p_dbl.DateByLevel(logger,
-                                                 job_input_dir,
-                                                 job_DATA_dir,
-                                                 model_info_dict,
-                                                 date_info_dict,
-                                                 plot_info_dict,
-                                                 met_info_dict, logo_dir)
-                    plot_dbl.make_date_by_level()
+                    plot_lbt.make_lead_by_threshold()
     else:
         logger.error(plot+" not recognized")
         sys.exit(1)

--- a/ush/plots/precip/precip_plots_specs.py
+++ b/ush/plots/precip/precip_plots_specs.py
@@ -82,7 +82,7 @@ class PlotSpecs:
             self.xtick_label_size = 15
             self.ytick_label_size = 15
         elif self.plot_type in ['lead_average', 'valid_hour_average',
-                                'threshold_average',
+                                'threshold_average', 'lead_by_threshold',
                                 'long_term_time_series_diff']:
             self.fig_size = (16., 16.)
             self.fig_subplot_top = 0.9
@@ -630,6 +630,8 @@ class PlotSpecs:
                         title_other_hr_list.append(str(other_hr).zfill(2)+'Z')
             title_other_hr_list.sort()
             date_plot_name = (date_plot_name+', '.join(plot_by_hr_list))
+                              #+', init. hours: '
+                              #+', '.join(title_other_hr_list))
         elif plot_by == 'INIT':
             for plot_by_hr in plot_by_hr_list:
                 for forecast_hour in forecast_hour_list:
@@ -645,7 +647,7 @@ class PlotSpecs:
             date_plot_name = (date_plot_name+', '.join(plot_by_hr_list)
                               +', valid: '+', '.join(title_other_hr_list))
         if plot_type not in ['lead_average', 'valid_hour_average',
-                             'lead_by_date', 'lead_by_level']:
+                             'lead_by_date', 'lead_by_level', 'lead_by_threshold']:
             forecast_day_list = []
             for forecast_hour in forecast_hour_list:
                 forecast_day = int(forecast_hour)/24.
@@ -712,9 +714,8 @@ class PlotSpecs:
                                 +int(date_info_dict['valid_hr_inc']),
                                 int(date_info_dict['valid_hr_inc']))
             ]
-        if self.plot_type in ['time_series', 'stat_by_level',
-                              'date_by_level',
-                              'performance_diagram', 'threshold_average']:
+        if self.plot_type in ['time_series','lead_by_level', 
+                              'threshold_average']:
             fhr_for_title = [date_info_dict['forecast_hour']]
         else:
             fhr_for_title = date_info_dict['forecast_hours']
@@ -729,7 +730,7 @@ class PlotSpecs:
             var_level_for_title = plot_info_dict['vert_profile']
         else:
             var_level_for_title = plot_info_dict['fcst_var_level']
-        if self.plot_type in ['performance_diagram', 'threshold_average']:
+        if self.plot_type in ['lead_by_threshold', 'threshold_average']:
             var_thresh_for_title = 'NA'
         else:
             var_thresh_for_title = plot_info_dict['fcst_var_thresh']
@@ -756,6 +757,9 @@ class PlotSpecs:
             plot_title = (plot_title+' '
                           +'Neighborhood Pts: '
                           +plot_info_dict['interp_points'])
+        #plot_title = (plot_title+' - '
+                      #+'Validation: '
+                      #+self.get_obs_plot_name(plot_info_dict['ob_name']))
         plot_title = (plot_title+'\n'
                       +self.get_dates_plot_name(date_info_dict['plot_by'],
                                                 date_info_dict['start_date'],
@@ -830,11 +834,13 @@ class PlotSpecs:
             plot_type_savefig_name = 'threshmean'
         elif self.plot_type == 'valid_hour_average':
             plot_type_savefig_name = 'vhrmean'
+        elif self.plot_type == 'lead_by_threshold':
+            plot_type_savefig_name = 'lead_by_threshold'
         else:
             plot_type_savefig_name = self.plot_type.replace('_', '')
         if self.plot_type in ['time_series', 'time_series_multifhr',
                               'lead_average', 'stat_by_level', 'lead_by_level',
-                              'lead_by_date', 'date_by_level',
+                              'lead_by_date', 'date_by_level', 'lead_by_threshold',
                               'performance_diagram', 'threshold_average']:
             plot_type_savefig_name = plot_type_savefig_name+'_valid'
             valid_hr = int(date_info_dict['valid_hr_start'])
@@ -843,8 +849,7 @@ class PlotSpecs:
                                           +str(valid_hr).zfill(2))
                 valid_hr+=int(date_info_dict['valid_hr_inc'])
             plot_type_savefig_name = plot_type_savefig_name+'Z'
-        if self.plot_type in ['time_series', 'date_by_level',
-                              'stat_by_level', 'performance_diagram',
+        if self.plot_type in ['time_series', 
                               'threshold_average']:
             plot_type_savefig_name = (
                  plot_type_savefig_name+'_'
@@ -857,7 +862,7 @@ class PlotSpecs:
                             f in date_info_dict['forecast_hours']])
             )
         elif self.plot_type in ['lead_average', 'lead_by_level',
-                                'lead_by_date']:
+                                'lead_by_date', 'lead_by_threshold']:
             plot_type_savefig_name = (
                  plot_type_savefig_name+'_'
                  +'f'+str(date_info_dict['forecast_hours'][-1]).zfill(3)
@@ -972,7 +977,7 @@ class PlotSpecs:
                  subplot0_cmap  - colormap for subplot 0
                  subplotsN_cmap - colormap for other subplots
         """
-        if stat in ['BIAS', 'ME', 'FBIAS']:
+        if stat in ['BIAS', 'ME', 'FBIAS', 'ETS']:
             cmap_bias_original = plt.cm.PiYG_r
             colors_bias = cmap_bias_original(
                 np.append(np.linspace(0,0.3,10), np.linspace(0.7,1,10))
@@ -982,7 +987,7 @@ class PlotSpecs:
             )
         else:
             subplot0_cmap = plt.cm.BuPu_r
-        if stat in ['BIAS', 'ME', 'FBIAS']:
+        if stat in ['BIAS', 'ME', 'FBIAS', 'ETS']:
             subplotsN_cmap = subplot0_cmap
         else:
             if stat == 'RMSE':
@@ -1062,74 +1067,20 @@ class PlotSpecs:
         """
         have_subplot0_levs = False
         subplot0_levs = np.array([np.nan])
-        if stat == 'ACC':
+        if stat == 'ETS':
             have_subplot0_levs = True
-            subplot0_levs = np.array([0.0, 0.25, 0.5, 0.6, 0.7, 0.8,
-                                      0.9, 0.95, 0.99, 1])
-        elif not np.ma.masked_invalid(subplot0_data).mask.all():
-            cmax = np.nanmax(subplot0_data)
-            if cmax > 100:
-                spacing = 2.25
-            elif cmax > 10:
-                spacing = 2
-            else:
-                spacing = 1.75
-            if stat == 'RMSE':
-                steps = 12
-                dx = 1.0 / (steps-1)
-                have_subplot0_levs = True
-                subplot0_levs = np.array(
-                    [0+(i*dx)**spacing*cmax for i in range(steps)],
-                    dtype=float
-                )
-            elif stat in ['BIAS', 'ME', 'FBIAS']:
-                if stat in ['BIAS', 'ME']:
-                    center_value = 0
-                elif stat == 'FBIAS':
-                    center_value = 1
-                have_subplot0_levs = True
-                subplot0_levs = self.get_centered_contour_levels(
-                    subplot0_data, center_value, spacing
-                )
-        have_subplotsN_levs = False
-        subplotsN_levs = np.array([np.nan])
-        if stat == 'ACC':
             have_subplotsN_levs = True
-            subplotsN_levs = np.array([-0.5, -0.4, -0.3, -0.2, -0.1, -0.05,
-                                       0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5])
-        else:
-            if np.shape(subplotsN_data) != np.shape([np.nan]):
-                if stat in ['BIAS', 'ME', 'FBIAS']:
-                    have_subplotsN_levs = have_subplot0_levs
-                    subplotsN_levs = subplot0_levs
-                if not have_subplotsN_levs:
-                    #for N in range(len(subplotsN_data[:,0,0])):
-                    for N in range(len(np.array(subplotsN_data)[:,0,0])):
-                        if stat in ['BIAS', 'ME', 'FBIAS']:
-                            #subplotN_data = subplotsN_data[N,:,:]
-                            subplotN_data = np.array(subplotsN_data)[N,:,:]
-                            if np.nanmax(subplotN_data) > 100:
-                                spacing = 2.25
-                            elif np.nanmax(subplotN_data) > 100:
-                                spacing = 2
-                            else:
-                                spacing = 1.75
-                            if stat in ['BIAS', 'ME']:
-                                center_value = 0
-                            elif stat == 'FBIAS':
-                                center_value = 1
-                        else:
-                            #subplotN_data = (subplotsN_data[N,:,:]
-                            subplotN_data = (np.array(subplotsN_data)[N,:,:]
-                                             - subplot0_data)
-                            center_value = 0
-                            spacing = 1.25
-                        if not np.ma.masked_invalid(subplotN_data).mask.all():
-                            have_subplotsN_levs = True
-                            subplotsN_levs = self.get_centered_contour_levels(
-                                subplotN_data, center_value, spacing
-                            )
-                            break
+            subplot0_levs = np.array([0.06, 0.12, 0.18, 0.24, 0.3, 0.36,
+                                       0.42, 0.48, 0.54, 0.6, 0.66, 0.72])
+            subplotsN_levs = np.array([0.06, 0.12, 0.18, 0.24, 0.3, 0.36,
+                                       0.42, 0.48, 0.54, 0.6, 0.66, 0.72])
+        elif stat == 'FBIAS':
+            have_subplot0_levs = True
+            have_subplotsN_levs = True
+            subplot0_levs = np.array([0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0, 1.1, 1.2,
+                                       1.4, 1.6, 2.0, 2.4, 2.8])
+            subplotsN_levs = np.array([0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0, 1.1, 1.2,
+                                       1.4, 1.6, 2.0, 2.4, 2.8])
         return have_subplot0_levs, subplot0_levs, have_subplotsN_levs, subplotsN_levs
 
     def get_vert_profile_levels(self, vert_profile):

--- a/ush/plots/precip/precip_plots_specs.py
+++ b/ush/plots/precip/precip_plots_specs.py
@@ -630,8 +630,6 @@ class PlotSpecs:
                         title_other_hr_list.append(str(other_hr).zfill(2)+'Z')
             title_other_hr_list.sort()
             date_plot_name = (date_plot_name+', '.join(plot_by_hr_list))
-                              #+', init. hours: '
-                              #+', '.join(title_other_hr_list))
         elif plot_by == 'INIT':
             for plot_by_hr in plot_by_hr_list:
                 for forecast_hour in forecast_hour_list:
@@ -757,9 +755,6 @@ class PlotSpecs:
             plot_title = (plot_title+' '
                           +'Neighborhood Pts: '
                           +plot_info_dict['interp_points'])
-        #plot_title = (plot_title+' - '
-                      #+'Validation: '
-                      #+self.get_obs_plot_name(plot_info_dict['ob_name']))
         plot_title = (plot_title+'\n'
                       +self.get_dates_plot_name(date_info_dict['plot_by'],
                                                 date_info_dict['start_date'],

--- a/ush/plots/precip/step2_precip_create_job_scripts.py
+++ b/ush/plots/precip/step2_precip_create_job_scripts.py
@@ -386,7 +386,7 @@ for ccpa_accum24hr_job in list(make_plots_jobs_dict['ccpa_accum24hr'].keys()):
         'CTC/ETS', 'CTC/FBIAS'
     ]
     make_plots_jobs_dict['ccpa_accum24hr']['24hrCCPA']['plots'] = [
-        'time_series', 'lead_average', 'threshold_average'
+        'time_series', 'lead_average', 'threshold_average', 'lead_by_threshold'
     ] 
 
 if JOB_GROUP == 'make_plots':
@@ -532,7 +532,7 @@ for case_type in case_type_list:
                 else:
                     plot_valid_hrs_loop = valid_hrs
                 if job_env_dict['plot'] in ['threshold_average',
-                                            'performance_diagram']:
+                                            'lead_by_threshold']:
                     plot_fcst_threshs_loop = [
                         case_type_plot_jobs_dict[case_type_job]\
                         ['fcst_var_dict']['threshs']
@@ -577,7 +577,7 @@ for case_type in case_type_list:
                         ).zfill(2)
                         job_env_dict['valid_hr_inc'] = str(valid_hr_inc)
                     if job_env_dict['plot'] in ['threshold_average',
-                                                'performance_diagram']:
+                                                'lead_by_threshold']:
                         job_env_dict['fcst_var_thresh_list'] = ', '.join(
                             plot_loop_info[1]
                         )

--- a/ush/plots/precip/verif_global_util.py
+++ b/ush/plots/precip/verif_global_util.py
@@ -980,7 +980,7 @@ def get_daily_stat_file(model_name, source_stats_base_dir,
                                          source directory (string)
              dest_model_name_stats_dir - full path to model
                                          destintion directory (string)
-             verif_case                - grid2grid or grid2obs (string)
+             verif_case                - grid2grid or grid2obs or precip (string)
              start_date_dt             - month start date (datetime obj)
              end_date_dt               - month end date (datetime obj)
          Returns:

--- a/ush/plotting_scripts/plot_time_series.py
+++ b/ush/plotting_scripts/plot_time_series.py
@@ -673,13 +673,19 @@ for plot_info in plot_info_list:
                 len(model_stat_values_array[0,:])
                 - np.ma.count_masked(model_stat_values_array[0,:])
             )
-            plot_time_dates_m = np.ma.masked_where(
-                np.ma.getmask(model_stat_values_array[0,:]), plot_time_dates
-            )
-            plot_time_dates_mc = np.ma.compressed(plot_time_dates_m)
-            model_stat_values_mc = np.ma.compressed(
+
+            expected_interval = plot_util.infer_expected_interval(
+                plot_time_dates,
                 model_stat_values_array[0,:]
             )
+
+            plot_time_dates_mc, model_stat_values_mc = plot_util.make_discontinuous(
+                plot_time_dates,
+                model_stat_values_array[0,:],
+                expected_interval
+            )
+
+
             #### EMC-verif_global plot model
             if count != 0:
                 logger.debug("Plotting model "+str(model_num)+" "

--- a/ush/plotting_scripts/plot_util.py
+++ b/ush/plotting_scripts/plot_util.py
@@ -4,6 +4,7 @@ import time
 import numpy as np
 import pandas as pd
 import warnings
+from collections import Counter
 warnings.filterwarnings('ignore')
 
 """!@namespace plot_util
@@ -1074,3 +1075,92 @@ def get_ci_file(stat, input_filename, fcst_lead, output_base_dir, ci_method):
     CI_file = os.path.join(output_base_dir, 'data',
                            CI_filename)
     return CI_file
+
+def make_discontinuous(time_array, data_array, expected_interval):
+    """
+    Insert NaNs only where actual valid data points are missing at the expected time interval.
+
+    Args:
+        time_array : array-like
+            Original time coordinates.
+        data_array : array-like
+            Original data values aligned with time_array.
+        expected_interval : float
+            Expected spacing between valid data points.
+
+    Returns:
+        time_out, data_out : np.ndarray
+            Arrays containing the original data and time points plus NaNs that represent
+            gaps due to undefined data.
+    """
+    # return time_array and data_array as is if time_array is empty or only contains one element
+    if len(time_array) <= 1:
+        return np.asarray(time_array), np.asarray(data_array)
+
+    data_masked = np.ma.masked_invalid(data_array)
+    time_out = [time_array[0]]
+    data_out = [data_array[0]]
+
+    prev_idx = 0
+    for i in range(1, len(time_array)):
+        if not data_masked.mask[i]:
+            # check interval from previous valid point
+            if (time_array[i] - time_array[prev_idx]) != expected_interval:
+                time_out.append(np.nan)
+                data_out.append(np.nan)
+            time_out.append(time_array[i])
+            data_out.append(data_array[i])
+            prev_idx = i
+
+    return np.array(time_out), np.array(data_out)
+
+def infer_expected_interval(time_array, data_array):
+    """
+    Infer expected interval between meaningful data points even when
+    much of the data is undefined. Falls back to the minimum
+    time spacing in time_array if too few valid data points exist.
+
+    Args:
+        time_array : array-like
+            Original time coordinates.
+        data_array : array-like
+            Original data values aligned with time_array.
+
+    Returns:
+        expected_interval : float
+            The inferred expected spacing between valid data points.
+    """
+
+    # convert time_array to a numpy array
+    time_array = np.asarray(time_array)
+
+    # Step 1: valid data_array indices (non-NaN points)
+    valid_idxs = np.where(~np.isnan(data_array))[0]
+
+    # Criteria for using valid data directly
+    # (1) need at least two points in data_array to form an interval
+    # (2) need at least 10% of data_array to be valid points
+    enough_valid = len(valid_idxs) >= 2
+    min_fraction_valid = 0.1
+    meets_fraction = (len(valid_idxs) / len(time_array)) >= min_fraction_valid if len(time_array) > 0 else False
+ 
+    # Step 2: compute intervals using valid points only
+    if enough_valid and meets_fraction:
+        # Calculate the intervals between consecutive valid data points
+        valid_intervals = np.diff(time_array[valid_idxs])
+
+        # Count how many times each interval occurs
+        interval_counts = Counter(valid_intervals)
+        # Select the most frequent interval
+        expected_interval = interval_counts.most_common(1)[0][0]
+        return expected_interval
+
+    # Step 3: Fallback: calculate smallest interval in the raw time array
+    time_diffs = np.diff(time_array)
+
+    if len(time_diffs) == 0:
+        # Time_array has 0 or 1 points, therefore no interval can be inferred
+        return 0
+
+    base_interval = np.min(time_diffs)
+    return base_interval


### PR DESCRIPTION
This PR is to 
  (1) Add the plot of threshold average_by lead average precip STEP2 in spack_stack_1.9.3 version. 
  (2) Allow gaps between undefined data in the time series plot  

https://www.emc.ncep.noaa.gov/bzhou/evs_plots/EMC_verif-global/ss193_step2_add_threshmean_add_leadbythreshold/precip.ets.apcp_a24.lead_by_threshold_valid12z_f240.g211_conus.png

**Developer Questions and Checklist**
Is this a high priority PR? Yes, (deadline is coming soon)
Do you have any planned upcoming annual leave/PTO? No

**Testing Instructions**
Before testing, change the following settings in parm/config/driver_standalone_step2_plots.sh
export RUN_PRECIP_STEP2="YES" and set other RUN_* = "NO"
export model_stat_dir_list="/gpfs/f6/ira-sti/world-shared/Binbin.Zhou/KEEP_archive/prod /gpfs/f6/ira-sti/world-shared/Binbin.Zhou/KEEP_archive/dev"
export OUTPUTROOT="/gpfs/f6/drsa-precip3/world-shared/$USER/verif_global_standalone_step2_precip"
export start_date=20241117
export end_date=20241130

To run the job, cd into EMC_verif-global/ush/ and type
./run_verif_global.sh ../parm/config/driver_standalone_step2_plots.sh

There will be one tar file that is sent to the $tar_archive_dir after the job is done

The total execution time will be around 20 min

Note 1: in current version, there will be a lot of FutureWarnings in the log file. This type of warning is related to mixed data types in one list. This is OK for current python, but maybe an issue in the future version of python. But currently this does not
have impact on running the python scripts.


