### PR TITLE
Apply new python code for scorecard generation in ss193

### DIFF
--- a/parm/config/driver_standalone_step2_plots.sh
+++ b/parm/config/driver_standalone_step2_plots.sh
@@ -24,9 +24,9 @@ echo "BEGIN: $(basename ${BASH_SOURCE[0]})"
 #RUN_TROPCYC:         runs METplus verification for tropical cyclone track and intensity error
 #RUN_MAPS2D:          run to make forecast maps including lat-lon and zonal-mean distributions
 #RUN_MAPSDA:          run to make analysis maps of time-mean increments, ENKF ensemble mean and ensemble spread
-export RUN_GRID2GRID_STEP2="NO"
+export RUN_GRID2GRID_STEP2="YES"
 export RUN_GRID2OBS_STEP2="NO"
-export RUN_PRECIP_STEP2="YES"
+export RUN_PRECIP_STEP2="NO"
 export RUN_SATELLITE_STEP2="NO"
 export RUN_FIT2OBS_PLOTS="NO"
 export RUN_TROPCYC="NO"
@@ -43,8 +43,8 @@ export RUN_MAPSDA="NO"
 #model_stat_dir_list:    directory path to model .stat files
 export prod_ver=16
 export dev_ver=17
-export model_list="gfsv${prod_ver} gfsv${dev_ver}"
-export model_stat_dir_list="/gpfs/f6/ira-sti/world-shared/$USER/KEEP_archive/prod /gpfs/f6/ira-sti/world-shared/$USER/KEEP_archive/dev"
+export model_list="gfsv${prod_ver} retrov17_01_stream4"
+export model_stat_dir_list="/gpfs/f6/ira-sti/world-shared/Ho-Chun.Huang/stats /gpfs/f6/ira-sti/world-shared/Ho-Chun.Huang/stats"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory
 export OUTPUTROOT="/gpfs/f6/drsa-precip3/world-shared/$USER/verif_global_standalone_step2"
@@ -57,8 +57,8 @@ export tar_archive_dir="/gpfs/f6/ira-sti/world-shared/$USER/KEEP_archive/tar_plo
 #spinup_period_end:   spinup period end, format YYYYMMDDHH, if none use "NA"
 #make_met_data_by:    how to treat dates, "VALID" or "INIT"
 #plot_by:             how to plot data, "VALID" or "INIT"
-export start_date=20241117
-export end_date=20241130
+export start_date=20250611
+export end_date=20250615
 export spinup_period_start="NA"
 export spinup_period_end="NA"
 export make_met_data_by="VALID"
@@ -112,33 +112,35 @@ if [ $RUN_GRID2GRID_STEP2 = YES ]; then
     #####    g2g2_[type]_event_eq:        do event equalization (True) or not (False)
     #####    g2g2_[type]_grid:            NCEP grid verification was done on
     #g2g2_make_scorecard: create scorecard (YES) or not (NO)
-    export g2g2_model_plot_name_list="GFSv${prod_ver} GFSv${dev_ver}"
+    export g2g2_model_plot_name_list="GFSv${prod_ver} RETROv17_01_stream4"
     export g2g2_type_list="anom pres sfc"
-    export g2g2_anom_truth_name_list="gfsv${prod_ver}_anl gfsv${dev_ver}_anl"
+    export g2g2_anom_truth_name_list="gfsv${prod_ver}_anl retrov17_01_stream4_anl"
     export g2g2_anom_gather_by_list="VALID VALID"
     export g2g2_anom_fcyc_list="00"
     export g2g2_anom_vhr_list="00"
     export g2g2_anom_fhr_min="00"
-    export g2g2_anom_fhr_max="120"
+    export g2g2_anom_fhr_max="240"
     export g2g2_anom_event_eq="False"
     export g2g2_anom_grid="G002"
-    export g2g2_pres_truth_name_list="gfsv${prod_ver}_anl gfsv${dev_ver}_anl"
+    export g2g2_pres_truth_name_list="gfsv${prod_ver}_anl retrov17_01_stream4_anl"
     export g2g2_pres_gather_by_list="VALID VALID"
     export g2g2_pres_fcyc_list="00"
     export g2g2_pres_vhr_list="00"
     export g2g2_pres_fhr_min="00"
-    export g2g2_pres_fhr_max="120"
+    export g2g2_pres_fhr_max="240"
     export g2g2_pres_event_eq="False"
     export g2g2_pres_grid="G002"
-    export g2g2_sfc_truth_name_list="gfsv${prod_ver}_f00 gfsv${dev_ver}_f00"
+    export g2g2_sfc_truth_name_list="gfsv${prod_ver}_f00 retrov17_01_stream4_f00"
     export g2g2_sfc_gather_by_list="VALID VALID"
     export g2g2_sfc_fcyc_list="00"
     export g2g2_sfc_vhr_list="00"
     export g2g2_sfc_fhr_min="00"
-    export g2g2_sfc_fhr_max="120"
+    export g2g2_sfc_fhr_max="240"
     export g2g2_sfc_event_eq="False"
     export g2g2_sfc_grid="G002"
-    export g2g2_make_scorecard="NO"
+    export g2g2_make_scorecard="YES"
+    export CI_METHOD="EMC"
+    export AVERAGE_METHOD="MEAN"
 fi
 
 if [ $RUN_GRID2OBS_STEP2 = YES ]; then

--- a/scripts/exgrid2grid_step2.sh
+++ b/scripts/exgrid2grid_step2.sh
@@ -68,8 +68,28 @@ status=$?
 [[ $status -eq 0 ]] && echo "Successfully ran create_step2_output_dirs.py"
 echo
 
+if [[ "$g2g2_make_scorecard" == "YES" ]]; then
+    IFS=' ' read -ra mdl_list <<< "${model_list}"
+    let num_mdl=${#mdl_list[@]}
+    if [[ $num_mdl -lt 2 ]]; then
+        echo "DEBUG :: The number of models defined in model_list is less than two."
+        echo "DEBUG :: Switch g2g2_make_scorecard from YES to NO"
+        export g2g2_make_scorecard="NO"
+        exec_procs="condense_stats filter_stats make_plots"
+    else
+        if [[ $num_mdl -gt 2 ]]; then
+            echo "DEBUG :: The number of models defined in model_list is more than two."
+            echo "DEBUG :: Will use the first two model for scorecard generation"
+        fi
+        exec_procs="condense_stats filter_stats scorecard_avg_ci make_plots"
+    fi
+else
+    exec_procs="condense_stats filter_stats make_plots"
+fi
+
+
 # Create and run job scripts for condense_stats, filter_stats, and make_plots
-for group in condense_stats filter_stats make_plots; do
+for group in ${exec_procs}; do
     export JOB_GROUP=$group
     echo "Creating and running jobs for grid-to-grid plots: ${JOB_GROUP}"
     python $USHverif_global/plots/grid2grid/step2_grid2grid_create_job_scripts.py
@@ -105,8 +125,8 @@ for group in condense_stats filter_stats make_plots; do
 done
 
 # Create scorecard, if needed
-if [ $g2g2_make_scorecard = YES ]; then
-    python $USHverif_global/plotting_scripts/plot_scorecard.py
+if [[ "$g2g2_make_scorecard" == "YES" ]]; then
+    python $USHverif_global/plots/grid2grid/plot_scorecard.py
     status=$?
     [[ $status -ne 0 ]] && exit $status
     [[ $status -eq 0 ]] && echo "Successfully ran plot_scorecard.py"

--- a/ush/plots/grid2grid/plot_scorecard.py
+++ b/ush/plots/grid2grid/plot_scorecard.py
@@ -72,7 +72,7 @@ def get_day_value(filename, filename_cols, day):
         day_value = np.nan
     return day_value
 
-# Scorecard informatdddion
+# Scorecard information
 model1 = model_list[0].replace("-","_")
 model2 = model_list[1].replace("-","_")
 col_region_list = ['PNA', 'NHX', 'SHX', 'TRO']

--- a/ush/plots/grid2grid/plot_scorecard.py
+++ b/ush/plots/grid2grid/plot_scorecard.py
@@ -1,0 +1,589 @@
+import pandas as pd
+import numpy as np
+import sys
+import os
+import datetime
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+# Read in environment variables
+machine = os.environ['machine']
+DATA = os.environ['DATA']
+NET = os.environ['NET']
+RUN = os.environ['RUN']
+USHverif_global = os.environ['USHverif_global']
+model_list = os.environ['model_list'].split(' ')
+start_date = os.environ['start_date']
+end_date = os.environ['end_date']
+plot_by = os.environ['plot_by']
+anom_truth_name_list = os.environ['g2g2_anom_truth_name_list'].split(' ')
+anom_fcyc_list = os.environ['g2g2_anom_fcyc_list'].split(' ')
+anom_vhr_list = os.environ['g2g2_anom_vhr_list'].split(' ')
+pres_truth_name_list = os.environ['g2g2_pres_truth_name_list'].split(' ')
+pres_fcyc_list = os.environ['g2g2_pres_fcyc_list'].split(' ')
+pres_vhr_list = os.environ['g2g2_pres_vhr_list'].split(' ')
+SEND2WEB = os.environ['SEND2WEB']
+webhost = os.environ['webhost']
+webhostid = os.environ['webhostid']
+webdir = os.environ['webdir']
+QUEUESERV = os.environ['QUEUESERV']
+ACCOUNT = os.environ['ACCOUNT']
+PARTITION_BATCH = os.environ['PARTITION_BATCH']
+
+# Set up job wall time information
+web_walltime = '180'
+walltime_seconds = datetime.timedelta(minutes=int(web_walltime)) \
+        .total_seconds()
+walltime = (datetime.datetime.min
+           + datetime.timedelta(minutes=int(web_walltime))).time()
+
+# Definitions
+def get_day_value(filename, filename_cols, day):
+    if os.path.exists(filename):
+        nrow = sum(1 for line in open(filename))
+        if nrow == 0:
+            print(filename+" empty")
+            day_value = np.nan
+        else:
+            filename_data = pd.read_csv(
+                filename, sep=' ', header=None,
+                names=filename_cols, dtype=str
+            )
+            filename_data_leads = (
+                filename_data.loc[:][filename_cols[0]].tolist()
+            )
+            filename_data_vals = (
+                filename_data.loc[:][filename_cols[1]].tolist()
+            )
+            day_hr_str = str(int(day)*24)+'0000'
+            if day_hr_str in filename_data_leads:
+                day_idx = filename_data_leads.index(
+                    str(int(day)*24)+'0000'
+                )
+                if filename_data_vals[day_idx] != '--':
+                    day_value = float(filename_data_vals[day_idx])
+                else:
+                    day_value = np.nan
+            else:
+                day_value = np.nan
+    else:
+        print(filename+" does not exist")
+        day_value = np.nan
+    return day_value
+
+# Scorecard informatdddion
+model1 = model_list[0].replace("-","_")
+model2 = model_list[1].replace("-","_")
+col_region_list = ['PNA', 'NHX', 'SHX', 'TRO']
+col_day_list = ['1', '3', '5', '6', '8', '10']
+row_stat_var_level_dict = {
+   'acc': {
+       'HGT': ['P250', 'P500', 'P700', 'P1000'],
+       'UGRD_VGRD': ['P250', 'P500', 'P850'],
+       'TMP': ['P250', 'P500', 'P850'],
+       'PRMSL': ['Z0']
+   },
+   'rmse': {
+       'HGT': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700', 'P850',
+               'P1000'],
+       'UGRD_VGRD': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700',
+                     'P850', 'P1000'],
+       'TMP': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700', 'P850',
+               'P1000']
+   },
+   'bias': {
+       'HGT': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700', 'P850',
+               'P1000'],
+       'UGRD_VGRD': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700',
+                     'P850', 'P1000'],
+       'TMP': ['P10', 'P20', 'P50', 'P100', 'P200', 'P500', 'P700', 'P850',
+               'P1000']
+   }
+}
+avg_file_cols = ['LEADS', 'VALS']
+CI_file_cols = ['LEADS', 'CI_VALS']
+
+# Make output directory
+scorecard_dir = os.path.join(DATA, RUN, 'scorecard')
+if not os.path.exists(scorecard_dir):
+    os.makedirs(scorecard_dir)
+
+# Set alpha values
+## alpha1: 95% confidence level
+## alpha2: 99% confidence level
+## alpha3: 99.9% confidence level
+start_date_dt = datetime.datetime.strptime(start_date, '%Y%m%d')
+end_date_dt = datetime.datetime.strptime(end_date, '%Y%m%d')
+ndays = (end_date_dt - start_date_dt).days + 1
+if ndays >= 80:
+    alpha1 = 1.960
+    alpha2 = 2.576
+    alpha3 = 3.291
+elif ndays >= 40 and ndays < 80:
+    alpha1=2.0
+    alpha2=2.66
+    alpha3=3.46
+elif ndays >= 20 and ndays < 40:
+    alpha1=2.042
+    alpha2=2.75
+    alpha3=3.646
+elif ndays < 20:
+    alpha1=2.228
+    alpha2=3.169
+    alpha3=4.587
+
+# Make CSS file
+scorecard_css_filename = os.path.join(scorecard_dir, 'scorecard.css')
+with open(scorecard_css_filename,'w') as scorecard_css_file:
+    scorecard_css_file.write('body {\n')
+    scorecard_css_file.write('        margin : 0;\n')
+    scorecard_css_file.write('        padding : 0;\n')
+    scorecard_css_file.write('        background-color : #ffffff;\n')
+    scorecard_css_file.write('        color : #000000;\n')
+    scorecard_css_file.write('        }\n')
+    scorecard_css_file.write('.first {\n')
+    scorecard_css_file.write('        border-collapse: collapse;\n')
+    scorecard_css_file.write('        border: 3px solid black;\n')
+    scorecard_css_file.write('        }\n')
+    scorecard_css_file.write('.second {\n')
+    scorecard_css_file.write('        border-collapse: collapse\n')
+    scorecard_css_file.write('        border: 1px dashed black;\n')
+    scorecard_css_file.write('}\n')
+    scorecard_css_file.write('.legend {\n')
+    scorecard_css_file.write('        font-size: 0.75em;\n')
+    scorecard_css_file.write('}\n')
+    scorecard_css_file.write('#bold {\n')
+    scorecard_css_file.write('        font: bold 1em Times;\n')
+    scorecard_css_file.write('        }\n')
+    scorecard_css_file.write('\n')
+    scorecard_css_file.write('td {\n')
+    scorecard_css_file.write('        border-collapse: collapse;\n')
+    scorecard_css_file.write('        border: 2px solid black;\n')
+    scorecard_css_file.write('}\n')
+    scorecard_css_file.write('th {\n')
+    scorecard_css_file.write('        border-collapse: collapse;\n')
+    scorecard_css_file.write('        border: 1px solid black;\n')
+    scorecard_css_file.write('        color: red;\n')
+    scorecard_css_file.write('        font-family: Garamound;\n')
+    scorecard_css_file.write('}\n')
+    scorecard_css_file.write('#thside {\n')
+    scorecard_css_file.write('        color: blue;\n')
+    scorecard_css_file.write('        font-family: Garamound;\n')
+    scorecard_css_file.write('}\n')
+
+# Make legend
+scorecard_legend_filename = os.path.join(scorecard_dir, 'legend.html')
+with open(scorecard_legend_filename, 'w') as scorecard_legend_file:
+    scorecard_legend_file.write('<link type="text/css" rel="stylesheet" '
+                                +'href="scorecard.css"/>\n')
+    scorecard_legend_file.write('<div>\n')
+    scorecard_legend_file.write('    <table class="second" cellpadding="0.2">'
+                                +'\n')
+    scorecard_legend_file.write('    <tr>\n')
+    scorecard_legend_file.write('       <th colspan=4>Scorecard Symbol '
+                                +'Legend</th>\n')
+    scorecard_legend_file.write('    </tr>\n')
+    scorecard_legend_file.write('    <tr class="legend">\n')
+    scorecard_legend_file.write('      <td><font color="#009120">&#9650;'
+                                +'</font></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is better than '
+                                +model1+' at the 99.9% significance '
+                                +'level</td>\n')
+    scorecard_legend_file.write('      <td><font color="#FF0000">&#9660;'
+                                +'</font></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is worse than '
+                                +model1+' at the 99.9% significance '
+                                +'level\n')
+    scorecard_legend_file.write('    </tr>\n')
+
+    scorecard_legend_file.write('    <tr class="legend">\n')
+    scorecard_legend_file.write('      <td><font color="#009120">&#9652;'
+                                +'</font></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is better than '
+                                +model1+' at the 99% significance '
+                                +'level</td>\n')
+    scorecard_legend_file.write('      <td><font color="#FF0000">&#9662;'
+                                +'</font></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is worse than '
+                                +model1+' at the 99% significance '
+                                +'level</td>\n')
+    scorecard_legend_file.write('    </tr>\n')
+    scorecard_legend_file.write('    <tr class="legend">\n')
+    scorecard_legend_file.write('      <td style="background:#A9F5A9"></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is better than '
+                                +model1+' at the 95% significance '
+                                +'level</td>\n')
+    scorecard_legend_file.write('      <td style="background:#F5A9BC"></td>\n')
+    scorecard_legend_file.write('      <td>'+model2+' is worse than '
+                                +model1+' at the 95% significance '
+                                +'level</td>\n')
+    scorecard_legend_file.write('    </tr>\n')
+    scorecard_legend_file.write('    <tr class="legend">\n')
+    scorecard_legend_file.write('      <td style="background:#BDBDBD"></td>\n')
+    scorecard_legend_file.write('      <td>No statistically significant '
+                                +'difference between '+model2+' and '
+                                +model1+'</td>\n')
+    scorecard_legend_file.write('      <td style="background:#58ACFA"</td>\n')
+    scorecard_legend_file.write('      <td>Not statistically relevant</td>\n')
+    scorecard_legend_file.write('    </tr>\n')
+    scorecard_legend_file.write('    <tr>\n')
+    scorecard_legend_file.write('      <th colspan=4>Dates: '
+                                +start_date+'-'+end_date+' </th>\n')
+    scorecard_legend_file.write('    </tr>\n')
+
+# Make column and row multi-index
+pd_cols_list = []
+for region in col_region_list:
+    for day in col_day_list:
+        pd_cols_list.append((region, day))
+pd_cols = pd.MultiIndex.from_tuples(pd_cols_list)
+pd_rows_list = []
+for stat in list(row_stat_var_level_dict.keys()):
+    var_level_dict = row_stat_var_level_dict[stat]
+    for var in list(var_level_dict.keys()):
+        for level in var_level_dict[var]:
+            pd_rows_list.append((stat, var, level))
+pd_rows = pd.MultiIndex.from_tuples(pd_rows_list)
+
+
+# Make dataframe
+# 1. Initialize as object to avoid dtype FutureWarning
+## scorecard_df = pd.DataFrame(np.nan, index=pd_rows, columns=pd_cols)
+scorecard_df = pd.DataFrame(np.nan, index=pd_rows, columns=pd_cols, dtype=object)
+
+# 2. Sort indices to avoid PerformanceWarning (lexsort depth)
+scorecard_df = scorecard_df.sort_index(axis=0).sort_index(axis=1)
+
+# Fill scorecard
+row_count = 0
+for pd_row in pd_rows_list:
+    stat = pd_row[0]
+    verif_var = pd_row[1]
+    level = pd_row[2]
+    # define interp_method and interp_point
+    if verif_var in ["HGT_WV1_0-20", "HGT_WV1_0-3", "HGT_WV1_10-20", "HGT_WV1_4-9"]:
+        parts = var_name.split("_", 1)
+        var = parts[0]
+        interp_method = parts[1].replace('-', '_')
+        interp_point = "na"
+    else:
+        var = verif_var
+        interp_method = "nearest"
+        interp_point = "1"
+    thresh = "na"
+
+    row_count+=1
+    print("Row "+str(row_count)+": "+stat+" "+var+" "+level)
+    if stat == 'acc':
+        verif_type = 'anom'
+        ## if both are set as self_anl
+        ## model1_truth_name = anom_truth_name_list[1].replace('self', model1)
+        ## model2_truth_name = anom_truth_name_list[1].replace('self', model2)
+        model1_truth_name = anom_truth_name_list[0]
+        model2_truth_name = anom_truth_name_list[1]
+        valid_hour_start = anom_vhr_list[0].zfill(2)
+        valid_hour_end = anom_vhr_list[-1].zfill(2)
+        init_hour_start = anom_fcyc_list[0].zfill(2)
+        init_hour_end = anom_fcyc_list[-1].zfill(2)
+        if var == 'UGRD_VGRD':
+            line_type = 'VAL1L2'
+        else:
+            line_type = 'SAL1L2'
+    else:
+        verif_type = 'pres'
+        ## if both are set as self_anl
+        ## model1_truth_name = pres_truth_name_list[1].replace('self', model1)
+        ## model2_truth_name = pres_truth_name_list[1].replace('self', model2)
+        model1_truth_name = pres_truth_name_list[0]
+        model2_truth_name = pres_truth_name_list[1]
+        valid_hour_start = pres_vhr_list[0].zfill(2)
+        valid_hour_end = pres_vhr_list[-1].zfill(2)
+        init_hour_start = pres_fcyc_list[0].zfill(2)
+        init_hour_end = pres_fcyc_list[-1].zfill(2)
+        if var == 'UGRD_VGRD':
+            line_type = 'VL1L2'
+        else:
+            line_type = 'SL1L2'
+    grid = os.environ[f"g2g2_{verif_type}_grid"]
+    for pd_col in pd_cols_list:
+        region = pd_col[0]
+        day = pd_col[1]
+        print("-- > Working on region: "+region+" day "+day)
+        model1_avg_file = os.path.join(
+            DATA, RUN, 'plot_output', 'plot_by_'+plot_by, 'scorecard_avg_ci',
+            line_type+'_'+verif_var+'_'+region, RUN.split('_')[0], verif_type,
+            'data', stat+'_fcst'+model1+'_'+var.lower()+level.lower()
+            +thresh+'_obs'+model1_truth_name+'_'+var.lower()+level.lower()
+            +thresh+'_linetype'+line_type.lower()+'_grid'+grid.lower()+'_vxmask'
+            +region.lower()+'_interp'+interp_method.lower()+interp_point.lower()
+            +'_valid'+start_date+valid_hour_start+'0000to'+end_date+valid_hour_start
+            +'0000_fcst_lead_avgs.stat.txt'
+        )
+        if os.path.exists(model1_avg_file):
+            ## print("Model 1 average file: "+model1_avg_file)
+            print("Found Model 1 average file")
+        else:
+            print("MISSING : "+model1_avg_file)
+            sys.exit()
+        model1_avg_value = get_day_value(model1_avg_file, avg_file_cols, day)
+        ## print("Model 1 average value: "+str(model1_avg_value))
+        model2_avg_file = os.path.join(
+            DATA, RUN, 'plot_output', 'plot_by_'+plot_by, 'scorecard_avg_ci',
+            line_type+'_'+verif_var+'_'+region, RUN.split('_')[0], verif_type,
+            'data', stat+'_fcst'+model2+'_'+var.lower()+level.lower()
+            +thresh+'_obs'+model2_truth_name+'_'+var.lower()+level.lower()
+            +thresh+'_linetype'+line_type.lower()+'_grid'+grid.lower()+'_vxmask'
+            +region.lower()+'_interp'+interp_method.lower()+interp_point.lower()
+            +'_valid'+start_date+valid_hour_start+'0000to'+end_date+valid_hour_start
+            +'0000_fcst_lead_avgs.stat.txt'
+        )
+        if os.path.exists(model2_avg_file):
+            ## print("Model 2 average file: "+model2_avg_file)
+            print("Found Model 2 average file")
+        else:
+            print("MISSING : "+model2_avg_file)
+            sys.exit()
+        model2_avg_value = get_day_value(model2_avg_file, avg_file_cols, day)
+        ## print("Model 2 average value: "+str(model2_avg_value))
+        model2_CI_file = os.path.join(
+            DATA, RUN, 'plot_output', 'plot_by_'+plot_by, 'scorecard_avg_ci',
+            line_type+'_'+verif_var+'_'+region, RUN.split('_')[0], verif_type,
+            'data', stat+'_fcst'+model2+'_'+var.lower()+level.lower()
+            +thresh+'_obs'+model2_truth_name+'_'+var.lower()+level.lower()
+            +thresh+'_linetype'+line_type.lower()+'_grid'+grid.lower()+'_vxmask'
+            +region.lower()+'_interp'+interp_method.lower()+interp_point.lower()
+            +'_valid'+start_date+valid_hour_start+'0000to'+end_date+valid_hour_start
+            +'0000_fcst_lead_avgs.stat_CI_EMC.txt'
+        )
+        if os.path.exists(model2_CI_file):
+            ## print("Model 2 CI file: "+model2_CI_file)
+            print("Found Model 2 CI file")
+        else:
+            print("MISSING : "+model2_CI_file)
+            sys.exit()
+        model2_CI_value = get_day_value(model2_CI_file, CI_file_cols, day)
+        ## print("Model 2 CI value: "+str(model2_CI_value))
+        if not np.isnan(model1_avg_value) and not np.isnan(model2_avg_value) \
+                and not np.isnan(model2_CI_value):
+            if stat == 'bias':
+                ds = np.abs(
+                    model1_avg_value - model2_avg_value
+                )/model2_CI_value
+                sss = np.abs(model1_avg_value) - np.abs(model2_avg_value)
+                if sss < 0:
+                    ds = -1 * ds
+            elif stat == 'rmse':
+                ds = (model1_avg_value - model2_avg_value)/model2_CI_value
+            else:
+                ds = (model2_avg_value - model1_avg_value)/model2_CI_value
+        else:
+            ds = np.nan
+        if not np.isnan(ds):
+            ds95 = ds
+            ds99 = ds * alpha1/alpha2
+            ds999 = ds * alpha1/alpha3
+            if ds999 >= 1:
+                print(model2+" is better than "+model1+" at the "
+                      +"99.9% significance level")
+                symbol = '<td style="width:30px"><font color="#009120">&#9650;</font></td>'
+            elif ds999 < 1 and ds99 >= 1:
+                print(model2+" is better than "+model1+" at the "
+                      +"99% significance level")
+                symbol = '<td style="width:30px"><font color="#009120">&#9652;</font></td>'
+            elif ds99 < 1 and ds95 >= 1:
+                print(model2+" is better than "+model1+" at the "
+                      +"95% significance level")
+                symbol = '<td style="background:#A9F5A9;width:30px"></td>'
+            elif ds95 > -1 and ds95 < 1:
+                print("No statistically significant difference between "
+                      +model2+" and "+model1)
+                symbol = '<td style="background:#BDBDBD;width:30px"></td>'
+            elif ds95 <= -1 and ds99 > -1:
+                print(model2+" is worse than "+model1+" at the "
+                      +"95% significance level")
+                symbol = '<td style="background:#F5A9BC;width:30px"></td>'
+            elif ds99 <= -1 and ds999 > -1:
+                print(model2+" is worse than "+model1+" at the "
+                      +"99% significance level")
+                symbol =  '<td style="width:30px"><font color="#FF0000">&#9662;</font></td>'
+            elif ds999 <= -1:
+                print(model2+" is worse than "+model1+" at the "
+                      +"99.9% significance level")
+                symbol = '<td style="width:30px"><font color="#FF0000">&#9660;</font></td>'
+        else:
+            symbol = '<td style="width:30px">M</td>'
+        if stat == 'acc' and region == 'TRO':
+            symbol = '<td style="background:#58ACFA;width:30px"></td>'
+        scorecard_df.loc[pd_row, (region, day)] = symbol
+
+# Make header html
+header_html_filename = os.path.join(scorecard_dir, 'header.html')
+with open(header_html_filename, 'w') as header_html_file:
+    header_html_file.write('<link type="text/css" rel="stylesheet" '
+                           +'href="scorecard.css"/>\n')
+    header_html_file.write('<table class="first" cellpadding="0.2">\n')
+    header_html_file.write(' <tbody align="center">\n')
+    header_html_file.write('  <!--Regions-->\n')
+    header_html_file.write('  <tr>\n')
+    header_html_file.write('   <th></th>\n')
+    header_html_file.write('   <th></th>\n')
+    header_html_file.write('   <th></th>\n')
+    for region in col_region_list:
+        if region == 'G002':
+            region_header_name = 'Globe'
+        elif region == 'NHX':
+            region_header_name = 'N. Hemisphere'
+        elif region == 'SHX':
+            region_header_name = 'S. Hemisphere'
+        elif region == 'TRO':
+            region_header_name = 'Tropics'
+        elif region == 'PNA':
+            region_header_name = 'N. America'
+        else:
+            print("ERROR: Do not recognize region "+region)
+            sys.exit(1)
+        header_html_file.write('    <th colspan='+str(len(col_day_list))
+                               +' >'+region_header_name+'</th>\n')
+    header_html_file.write('  </tr>\n')
+    header_html_file.write('  <!--Days-->\n')
+    header_html_file.write('   <tr>\n')
+    header_html_file.write('    <td style="width:150px"></td>\n')
+    header_html_file.write('    <td style="width:75px"></td>\n')
+    header_html_file.write('    <td style="width:75px"></td>\n')
+    for region in col_region_list:
+        for day in col_day_list:
+            day_idx = col_day_list.index(day)
+            if (day_idx % 2) == 0:
+                 day_header_bg_color = '#FFFFFF'
+            else:
+                 day_header_bg_color = '#E6E6E6'
+            header_html_file.write('    <td style="background:'
+                                   +day_header_bg_color+';width:30px">Day '+day
+                                   +'</td>\n')
+    header_html_file.write('   </tr>\n')
+    header_html_file.write(' </tbody>\n')
+    header_html_file.write('</table>\n')
+
+# Make scorecard html
+scorecard_html_filename = os.path.join(scorecard_dir, 'scorecard.html')
+with open(scorecard_html_filename, 'w') as scorecard_html_file:
+    scorecard_html_file.write('<link type="text/css" rel="stylesheet" '
+                              +'href="scorecard.css"/>\n')
+    scorecard_html_file.write('<table class="first" cellpadding="0.2">\n')
+    scorecard_html_file.write(' <tbody align="center">\n')
+    for stat in list(row_stat_var_level_dict.keys()):
+        stat_span = 0
+        var_level_dict = row_stat_var_level_dict[stat]
+        for var in list(var_level_dict.keys()):
+            for level in var_level_dict[var]:
+                stat_span+=1
+        if stat == 'acc':
+            stat_scorecard_name = 'Anomaly Correlation Coefficient'
+        elif stat == 'rmse':
+            stat_scorecard_name = 'RMSE'
+        elif stat == 'bias':
+            stat_scorecard_name = 'Bias'
+        else:
+            print("ERROR: Do not recognize stat "+stat)
+            sys.exit(1)
+        scorecard_html_file.write('   <tr>\n')
+        scorecard_html_file.write('    <th id="thside" rowspan="'
+                                  +str(stat_span)+'" style="width:150px">'
+                                  +stat_scorecard_name+'</th>\n')
+        for var in list(var_level_dict.keys()):
+            var_span = str(len(var_level_dict[var]))
+            if var == 'HGT':
+                var_scorecard_name = 'Heights'
+            elif var == 'PRMSL':
+                var_scorecard_name = 'MSLP'
+            elif var == 'TMP':
+                var_scorecard_name = 'Temp'
+            elif var == 'UGRD':
+                var_scorecard_name = 'U-Wind'
+            elif var == 'VGRD':
+                var_scorecard_name = 'V-Wind'
+            elif var == 'UGRD_VGRD':
+                if stat == 'bias':
+                    var_scorecard_name = 'Wind Speed'
+                else:
+                    var_scorecard_name = 'Vector Wind'
+            else:
+                print("ERROR: Do not recognize variable "+var)
+                sys.exit(1)
+            scorecard_html_file.write('     <td rowspan="'+var_span+'" '
+                                      +'style="width:75px">'
+                                      +var_scorecard_name+'</td>\n')
+            for level in var_level_dict[var]:
+                if level[0] == 'P':
+                    level_scorecard_name = level[1:]+'hPa'
+                elif var == 'PRMSL':
+                    level_scorecard_name = 'MSL'
+                else:
+                    print("ERROR: Do not recognize level "+level)
+                    sys.exit(1)
+                scorecard_html_file.write('     <td style="width:75px">'
+                                          +level_scorecard_name+'</td>\n')
+                for pd_col in pd_cols_list:
+                    region = pd_col[0]
+                    day = pd_col[1]
+                    scorecard_html_file.write('       '+scorecard_df.loc[
+                                                  (stat, var, level),
+                                                  (region, day)
+                                              ]+'\n')
+                scorecard_html_file.write('   </tr>\n')
+                scorecard_html_file.write('\n')
+                scorecard_html_file.write('   <tr>\n')
+    scorecard_html_file.write(' </tbody>\n')
+    scorecard_html_file.write('</table>\n')
+
+# Send to website
+if SEND2WEB == 'YES':
+    print("Webhost: "+webhost)
+    print("Webhost location: "+webdir)
+    # Create job card
+    web_job_filename = os.path.join(DATA, 'batch_jobs',
+                                    NET+'_'+RUN
+                                    +'_scorecard_web.sh')
+    with open(web_job_filename, 'a') as web_job_file:
+        web_job_file.write('#!/bin/sh'+'\n')
+        if machine == 'WCOSS2':
+            web_job_file.write('cd $PBS_O_WORKDIR\n')
+        web_job_file.write('ssh -q -l '+webhostid+' '+webhost+' " ls -l '
+                           +webdir+' "'+'\n')
+        web_job_file.write('if [ $? -ne 0 ]; then'+'\n')
+        web_job_file.write('    echo "Making directory '+webdir+'"'+'\n')
+        web_job_file.write('    ssh -q -l '+webhostid+' '+webhost
+                           +' "mkdir -p '+webdir+' "'+'\n')
+        web_job_file.write('    sleep 30\n')
+        web_job_file.write('    scp -q '+os.path.join(USHverif_global,
+                                                      'webpage.tar')+'  '
+                           +webhostid+'@'+webhost+':'+webdir+'/.'+'\n')
+        web_job_file.write('    ssh -q -l '+webhostid+' '+webhost
+                           +' "cd '+webdir+' ; tar -xvf webpage.tar "'+'\n')
+        web_job_file.write('    ssh -q -l '+webhostid+' '+webhost
+                           +' "rm '+os.path.join(webdir, 'webpage.tar')
+                           +' "'+'\n')
+        web_job_file.write('fi'+'\n')
+        web_job_file.write('\n')
+        web_job_file.write('scp -r '+os.path.join(DATA, RUN,
+                                                  'scorecard', '*')
+                           +' '+webhostid+'@'+webhost+':'
+                           +os.path.join(webdir, 'scorecard', '.'))
+    # Submit job card
+    os.chmod(web_job_filename, 0o755)
+    web_job_output = web_job_filename.replace('.sh', '.out')
+    web_job_name = web_job_filename.rpartition('/')[2].replace('.sh', '')
+    print("Submitting "+web_job_filename+" to "+QUEUESERV)
+    print("Output sent to "+web_job_output)
+    if machine == 'WCOSS2':
+        os.system('qsub -V -l walltime='+walltime.strftime('%H:%M:%S')+' '
+                  +'-q '+QUEUESERV+' -A '+ACCOUNT+' -o '+web_job_output+' '
+                  +'-e '+web_job_output+' -N '+web_job_name+' '
+                  +'-l select=1:ncpus=1 '+web_job_filename)
+    elif machine in ['HERA', 'ORION', 'S4', 'HERCULES', 'JET', 'GAEAC5', 'GAEAC6']:
+        os.system('sbatch --ntasks=1 --time='+walltime.strftime('%H:%M:%S')+' '
+                  +'--partition='+QUEUESERV+' --account='+ACCOUNT+' '
+                  +'--output='+web_job_output+' '
+                  +'--job-name='+web_job_name+' '+web_job_filename)
+

--- a/ush/plots/grid2grid/scorecard_avg_ci.py
+++ b/ush/plots/grid2grid/scorecard_avg_ci.py
@@ -1,0 +1,377 @@
+import os
+import numpy as np
+import pandas as pd
+import logging
+import verif_global_util as vfg_util
+
+def setup_logger():
+    """! Sets up a basic logger.
+
+            Returns:
+                logger - logging object configured to output INFO level messages to the console.
+    """
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        ch = logging.StreamHandler()
+        # Use a more visible format
+        formatter = logging.Formatter('%(levelname)s: %(message)s')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+    return logger
+
+def scorecard_read_stat_file(logger, file_path, column_list):
+    """! Reads a output file from "filter_stats" into a Pandas DataFrame.
+
+            Args:
+                logger      - logging object.
+                file_path   - string of the full path to the stats file.
+                column_list - list of strings containing the expected column names.
+
+            Returns:
+                df - Pandas DataFrame containing the data from the stat file,
+                     with 'FCST_VALID_BEG' set as the index, or an empty DataFrame
+                     if the file is missing or reading fails.
+    """
+    if not os.path.exists(file_path):
+        logger.info(f"Input file not found: {file_path}")
+        return pd.DataFrame(columns=column_list)
+        
+    try:
+        # NOTE: Assumes data structure aligned with column_list provided by get_met_line_type_cols
+        df = pd.read_csv(
+            file_path, sep=" ", skiprows=1,
+            skipinitialspace=True, names=column_list,
+            na_values=['NA'], header=None
+        )
+        
+        # Apply dtypes based on column list (MET standard)
+        df_dtype_dict = {}
+        float_idx = column_list.index('TOTAL')
+        for col in column_list:
+            col_idx = column_list.index(col)
+            df_dtype_dict[col] = str if col_idx < float_idx else np.float64
+        
+        df = df.astype(df_dtype_dict)
+        
+        # Set index to the date (FCST_VALID_BEG) for alignment stability
+        if 'FCST_VALID_BEG' in df.columns:
+            df = df.set_index('FCST_VALID_BEG')
+            
+        return df
+    except Exception as e:
+        logger.error(f"Failed to read or process file {file_path}: {e}")
+        return pd.DataFrame(columns=column_list)
+
+def scorecard_write_avg_ci(logger, filename, data_line, file_write_tracker):
+    """! Writes a line of data, ensuring the file is cleared on first write.
+
+            Args:
+                logger            - logging object.
+                filename          - string of the full path to the output file.
+                data_line         - string of the data to write.
+                file_write_tracker- dictionary used to track if a file has been written
+                                    to before in this run (keys are filenames).
+    """
+    
+    write_mode = 'a'
+    if filename not in file_write_tracker:
+        write_mode = 'w'
+        # Ensure directory exists before first write
+        vfg_util.make_dir(os.path.dirname(filename))
+        file_write_tracker[filename] = True
+        
+    try:
+        with open(filename, write_mode) as file2write:
+            file2write.write(data_line + '\n')
+    except Exception as e:
+        logger.error(f"Failed to write to file {filename}: {e}")
+
+
+def calculate_scorecard_avg_ci(
+    logger, line_type, metric, fcst_lead, number_of_days, 
+    modelA_df, modelB_df, modelA_name, modelB_name, 
+    ci_method, average_method, modelB_base_filename, output_base_dir,
+    file_write_tracker
+):
+    """! Calculates averages and CI of a metric and writes results for one lead time and average.
+         Write '--' if input DataFrames are empty (no common dates/data).
+
+            Args:
+                logger              - logging object.
+                line_type           - string of the MET line type (e.g., 'CNT', 'FHO').
+                metric              - string of the metric to calculate (e.g., 'rmse', 'bias', 'acc').
+                fcst_lead           - string of the forecast lead time (e.g., '006').
+                number_of_days      - integer count of the number of common dates in the data.
+                modelA_df           - Pandas DataFrame for the Model A aligned to common dates.
+                modelB_df           - Pandas DataFrame for the Model B aligned to common dates.
+                modelA_name         - string name of Model A (e.g., 'gfsv16').
+                modelB_name         - string name of Model B (e.g., 'gfsv17').
+                ci_method           - string of the confidence interval method (e.g., 'EMC').
+                average_method      - string of the averaging method (e.g., 'MEAN').
+                modelB_base_filename- string representing the base filename info for model B
+                                      (used to construct output paths).
+                output_base_dir     - string of the path to the directory for output files.
+                file_write_tracker  - dictionary for tracking initial file write.
+    """
+    
+    # Initialize values to "--" for the case of missing data
+    modelA_metric_avg = '--'
+    modelB_metric_avg = '--'
+    modelB_ci = '--'
+    
+    # Check if the aligned DataFrames contain any data (i.e., common_dates was not empty)
+    if modelA_df.empty or modelB_df.empty:
+        # If no common data, log and proceed to output writing with initialized '--' values
+        logger.info(
+            f"  Skipping calculation for {output_base_dir} {metric} (F{fcst_lead}): Aligned data is empty. Writing '--'."
+        )
+    else:
+        # --- Calculate Daily Metric Series ---
+        try:
+            modelA_metric_daily, modelA_metric_array, stat_plot_name = vfg_util.calculate_scorecard_stat(logger, modelA_df, metric)
+            modelB_metric_daily, modelB_metric_array, _ = vfg_util.calculate_scorecard_stat(logger, modelB_df, metric)
+            
+            # Check if the resulting metric arrays are valid for aggregation
+            # This check is crucial for handling cases where calculate_stat might return empty/invalid data 
+            # even if the raw DataFrame wasn't structurally empty, but was masked out.
+            if not modelA_metric_array.any() or not modelB_metric_array.any():
+                logger.info(f"  Skipping calculation for {metric}: Daily data array is empty or fully masked. Writing '--'.")
+            else:
+                modelA_daily_values = modelA_metric_array.flatten()
+                modelB_daily_values = modelB_metric_array.flatten()
+                
+                # --- Calculate Mean metric ---
+
+                modelA_daily_values_reshaped = modelA_daily_values.reshape(1, -1)
+                modelB_daily_values_reshaped = modelB_daily_values.reshape(1, -1)
+                
+                # Note: calculate_average returns a numpy array, take [0] to get the scalar value
+                modelA_metric_avg = vfg_util.calculate_scorecard_average(
+                    logger, average_method, metric, modelA_df, modelA_daily_values_reshaped
+                )[0]
+                modelB_metric_avg = vfg_util.calculate_scorecard_average(
+                    logger, average_method, metric, modelB_df, modelB_daily_values_reshaped
+                )[0]
+        
+                # --- Calculate CI for Model B vs Model A ---
+                
+                # Check dimensionality robustly: 1D (Series) implies one column, 2D (DataFrame) check shape[1]
+                modelA_ndim = modelA_metric_daily.ndim
+                num_cols = modelA_metric_daily.shape[1] if modelA_ndim == 2 else 1 # Assume 1 if Series (ndim=1)
+        
+                if num_cols == 1:
+                    if modelA_ndim == 1:
+                        modelA_daily_series = modelA_metric_daily
+                        modelB_daily_series = modelB_metric_daily
+                    else: # modelA_ndim == 2 (DataFrame with 1 column)
+                        modelA_daily_series = modelA_metric_daily.iloc[:, 0]
+                        modelB_daily_series = modelB_metric_daily.iloc[:, 0]
+                        
+                    # NOTE: total_days should be the number of rows in the aligned dataframe, which is modelA_df.shape[0]
+                    randx_data = np.random.rand(10000, modelA_df.shape[0]) 
+                    
+                    ci_result = vfg_util.calculate_ci(
+                        logger, 
+                        ci_method, 
+                        modelB_daily_series,
+                        modelA_daily_series,
+                        modelA_df.shape[0], 
+                        metric, 
+                        average_method, 
+                        randx_data
+                    )
+                    
+                    # Update modelB_ci only if calculation was successful (not the original string '--')
+                    if ci_result != '--':
+                        modelB_ci = ci_result
+                else:
+                    logger.info(f"  Skipping CI calculation for metric '{metric}' as it returns multiple columns ({num_cols}). Writing '--'.")
+        
+        except Exception as e:
+            logger.error(f"Failed to calculate stat for {metric} (F{fcst_lead}): {e}. Writing '--'.")
+
+
+    # --- Output Path Generation and Writing ---
+    
+    # Write Model A Average
+
+    # forecast hour output format
+    fcst_lead_string=fcst_lead.lstrip('0')+"0000"
+
+    modelA_avg_output_file = vfg_util.get_lead_avg_file(
+        metric, modelB_base_filename.replace(modelB_name, modelA_name), fcst_lead, output_base_dir 
+    )
+    scorecard_write_avg_ci(
+        logger, modelA_avg_output_file, f"{fcst_lead_string} {modelA_metric_avg}", file_write_tracker
+    )
+    logger.info(f"   Wrote {modelA_name} Avg to: {os.path.basename(modelA_avg_output_file)}")
+    
+    # Write Model B Average
+    modelB_avg_output_file = vfg_util.get_lead_avg_file(
+        metric, modelB_base_filename, fcst_lead, output_base_dir 
+    )
+    scorecard_write_avg_ci(
+        logger, modelB_avg_output_file, f"{fcst_lead_string} {modelB_metric_avg}", file_write_tracker
+    )
+    logger.info(f"   Wrote {modelB_name} Avg to: {os.path.basename(modelB_avg_output_file)}")
+    
+    # Write CI
+    ci_output_file = vfg_util.get_ci_file(
+        metric, modelB_base_filename, fcst_lead, output_base_dir, ci_method
+    )
+    scorecard_write_avg_ci(
+        logger, ci_output_file, f"{fcst_lead_string} {modelB_ci}", file_write_tracker
+    )
+    logger.info(f"   Wrote CI to: {os.path.basename(ci_output_file)}")
+
+
+def main():
+    """! Main function to drive the scorecard average and confidence interval calculation.
+         It reads configuration, iterates over forecast leads, reads and aligns two sets
+         of verification statistics for two models, and calculates/writes averages and CI.
+    
+            Returns:
+                0 for successful completion, -1 if the input directory is missing.
+    """
+    logger = setup_logger()
+
+    # --- Get CONFIGURATION SETTINGS ---
+    DATA            = os.environ["DATA"]          
+    met_root        = os.environ["HOMEMET"]          
+    met_version     = os.environ["MET_version"]
+    RUN             = os.environ["RUN"]          
+    case_type       = os.environ["CASE_TYPE"]          
+    JOB_GROUP       = os.environ["JOB_GROUP"]          
+    fhrs            = os.environ["fhr_list"]          
+    fcst_hr_list    = [str(int(fhr.strip())).zfill(3) for fhr in fhrs.split(',')]
+    run_case        = os.environ["RUN_CASE"]          
+    start_date      = os.environ["start_date"]          
+    end_date        = os.environ["end_date"]          
+    plot_by         = os.environ["plot_by"]          
+    grid            = os.environ["grid"]          
+    job_name        = os.environ["job_name"]          
+    valid_hr        = os.environ["valid_hr_list"]          
+    fcst_var_name   = os.environ["fcst_var_name"]          
+    obs_var_name    = os.environ["obs_var_name"]          
+    fcst_var_level  = os.environ["fcst_var_level"]          
+    obs_var_level   = os.environ["obs_var_level"]          
+    model_list      = os.environ["model_list"]          
+    models = [m.strip() for m in model_list.split(",")]
+    if len(models) >= 2:
+        model1_name     = models[0]
+        model2_name     = models[1]
+    else:
+        logger.info(f"The number of input model list is less than 2")
+    obs_list        = os.environ["obs_list"]          
+    models = [m.strip() for m in obs_list.split(",")]
+    if len(models) >= 2:
+        model1_truth    = models[0]
+        model2_truth    = models[1]
+    else:
+        logger.info(f"The number of input truth list is less than 2")
+    line_type       = os.environ["line_type"]          
+    vx_mask         = os.environ["vx_mask"]          
+    fcst_var_thresh = os.environ["fcst_var_thresh"]          
+    obs_var_thresh  = os.environ["obs_var_thresh"]          
+    interp_method   = os.environ["interp_method"]          
+    interp_points   = os.environ["interp_points"]          
+    job_DATA_dir    = os.environ["job_DATA_dir"]          
+    metric          = os.environ["metric"]          
+    ci_method       = os.environ["CI_METHOD"]      ##  "EMC"
+    average_method  = os.environ["AVERAGE_METHOD"] ##  "MEAN"
+    
+    ## input_dir = "/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/verif_global/grid2grid_step2/plot_output/plot_by_VALID/filter_stats"
+    input_dir = os.path.join( os.path.dirname(job_DATA_dir), "filter_stats", case_type)
+
+    
+    ## if not os.path.exists(job_DATA_dir):
+    ##     os.makedirs(job_DATA_dir)
+    ##     logger.info(f"Created output base directory: {job_DATA_dir}")
+    if not os.path.exists(input_dir):
+        logger.info(f"Input stats directory: {input_dir} does not exist")
+        return -1
+    
+    met_version_line_type_col_list = vfg_util.get_met_line_type_cols(
+        logger, met_root, met_version, line_type
+    )
+
+    subdir_path = f"{line_type}_{job_name}_{vx_mask}/{run_case}/{case_type}"
+    output_stat_path = os.path.join( job_DATA_dir, subdir_path )
+    if not os.path.exists(output_stat_path):
+        vfg_util.make_dir(output_stat_path)
+                        
+    interp_method = interp_method.replace("-","_")
+    plevel=fcst_var_level.replace("-","_")
+
+    stats_info1=f"fcst{model1_name}_{fcst_var_name}{plevel}{fcst_var_thresh}_obs{model1_truth}"
+    stats_info2=f"fcst{model2_name}_{fcst_var_name}{plevel}{fcst_var_thresh}_obs{model2_truth}"
+    common_info = (
+        f"_{obs_var_name}{plevel}{obs_var_thresh}"
+        f"_linetype{line_type}_grid{grid}_vxmask{vx_mask}"
+        f"_interp{interp_method}{interp_points}"
+        f"_valid{start_date}{valid_hr}0000to{end_date}{valid_hr}0000"
+    )
+    input_filename1_prefix=stats_info1.lower()+common_info.lower()
+    input_filename2_prefix=stats_info2.lower()+common_info.lower()
+
+    file_write_tracker = {}
+                    
+    for fhr in fcst_hr_list:
+        input_filename_suffix=f"fhr{fhr}.stat"
+
+        input_filename1 = f"{input_filename1_prefix}_{input_filename_suffix}"
+        input_filename2 = f"{input_filename2_prefix}_{input_filename_suffix}"
+                        
+        # Define the full input paths
+        input_stats_path = input_dir # Use the defined input_dir
+        model1_input_file = os.path.join( input_stats_path, input_filename1 )
+        model2_input_file = os.path.join( input_stats_path, input_filename2 )
+                            
+        # --- START: FILE EXISTENCE CHECK ---
+                            
+        model1_exists = os.path.exists(model1_input_file)
+        model2_exists = os.path.exists(model2_input_file)
+
+        if not model1_exists or not model2_exists:
+            # Log a debug info for missing file(s) and skip to the next lead time
+            if not model1_exists:
+                logger.info(
+                    f"Missing file: {model1_name} for lead {fhr}hrs, level {plevel} {os.path.basename(model1_input_file)}"
+                )
+            if not model2_exists:
+                logger.info(
+                    f"Missing file: {model2_name} for lead {fhr}hrs, level {plevel} {os.path.basename(model2_input_file)}"
+                )
+            continue # Skip to the next 'fhr' iteration
+        
+        else:
+            # Read the dataframes once per lead time (scorecard_read_stat_file should set index to FCST_VALID_BEG)
+
+            modelA_stat_file_df = scorecard_read_stat_file(logger, model1_input_file, met_version_line_type_col_list)
+            modelB_stat_file_df = scorecard_read_stat_file(logger, model2_input_file, met_version_line_type_col_list)
+                    
+            # --- DATA ALIGNMENT ---
+            # 1. Find the dates common to both data sets
+            common_dates = modelA_stat_file_df.index.intersection(modelB_stat_file_df.index)
+                    
+            # 2. Filter both dataframes to use only common dates
+            modelA_df_aligned = modelA_stat_file_df.loc[common_dates].copy()
+            modelB_df_aligned = modelB_stat_file_df.loc[common_dates].copy()
+                    
+            aligned_df_length = len(common_dates)
+            ## logger.info(f"Using {aligned_df_length} common valid dates for calculation.")
+            # --- END DATA ALIGNMENT ---
+                            
+            # Pass the ALIGNED DastaFrames to the processing function
+
+            calculate_scorecard_avg_ci(
+                logger, line_type, metric, fhr, aligned_df_length,
+                modelA_df_aligned, modelB_df_aligned, model1_name, model2_name, 
+                ci_method, average_method, input_filename2, output_stat_path,
+                file_write_tracker
+            )
+    logger.info("\n--- Processing Complete ---")
+
+if __name__ == '__main__':
+    main()

--- a/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
+++ b/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
@@ -36,6 +36,8 @@ RUN_abbrev = os.environ['RUN_abbrev']
 case_type_list = os.environ[RUN_abbrev+'_type_list'].split(' ')
 met_ver = os.environ['MET_version']
 MET_ROOT = os.environ['HOMEMET']
+CI_METHOD = os.environ["CI_METHOD"]
+AVERAGE_METHOD = os.environ["AVERAGE_METHOD"]
 
 njobs = 0
 JOB_GROUP_jobs_dir = os.path.join(DATA, RUN,
@@ -354,6 +356,25 @@ for sfc_job in list(filter_stats_jobs_dict['sfc'].keys()):
 if JOB_GROUP == 'filter_stats':
     JOB_GROUP_dict = filter_stats_jobs_dict
 
+# scorecard_avg_ci jobs
+scorecard_avg_ci_jobs_dict = copy.deepcopy(filter_stats_jobs_dict)
+
+# anom
+for anom_job in list(scorecard_avg_ci_jobs_dict['anom'].keys()):
+    scorecard_avg_ci_jobs_dict['anom'][anom_job]['metric'] = ['acc']
+# pres
+for pres_job in list(scorecard_avg_ci_jobs_dict['pres'].keys()):
+    scorecard_avg_ci_jobs_dict['pres'][pres_job]['metric'] = [
+        'bias', 'rmse', 'msess', 'rsd', 'rmse_md', 'rmse_pv'
+    ]
+# sfc
+for sfc_job in list(scorecard_avg_ci_jobs_dict['sfc'].keys()):
+    scorecard_avg_ci_jobs_dict['sfc'][sfc_job]['metric'] = ['fbar']
+
+# Assign the final dictionary to JOB_GROUP_dict for return
+if JOB_GROUP == 'scorecard_avg_ci':
+    JOB_GROUP_dict = scorecard_avg_ci_jobs_dict
+
 # make_plots jobs
 make_plots_jobs_dict = copy.deepcopy(filter_stats_jobs_dict)
 # anom
@@ -428,7 +449,7 @@ for case_type in case_type_list:
             job_env_dict[case_type_env] = (
                 os.environ[RUN_abbrev_type+'_'+case_type_env]
             )
-        if JOB_GROUP in ['filter_stats', 'make_plots']:
+        if JOB_GROUP in ['filter_stats', 'scorecard_avg_ci', 'make_plots']:
             valid_hr_start = int(job_env_dict['valid_hr_beg'])
             valid_hr_end = int(job_env_dict['valid_hr_end'])
             valid_hr_inc = int(job_env_dict['valid_hr_inc'])
@@ -460,6 +481,15 @@ for case_type in case_type_list:
                 case_type_plot_jobs_dict[case_type_job]['fcst_var_dict']['threshs'],
                 case_type_plot_jobs_dict[case_type_job]['interps'],
                 valid_hrs
+            ))
+        elif JOB_GROUP == 'scorecard_avg_ci':
+            JOB_GROUP_case_type_job_product_loops = list(itertools.product(
+                case_type_plot_jobs_dict[case_type_job]['line_types'],
+                case_type_plot_jobs_dict[case_type_job]['fcst_var_dict']['levels'],
+                case_type_plot_jobs_dict[case_type_job]['vx_masks'],
+                case_type_plot_jobs_dict[case_type_job]['fcst_var_dict']['threshs'],
+                case_type_plot_jobs_dict[case_type_job]['interps'],
+                case_type_plot_jobs_dict[case_type_job]['metric']
             ))
         elif JOB_GROUP == 'make_plots':
             JOB_GROUP_case_type_job_product_loops = list(itertools.product(
@@ -507,6 +537,59 @@ for case_type in case_type_list:
                 job_env_dict['job_DATA_dir'] = job_DATA_dir
                 vfg_util.make_dir(job_env_dict['job_DATA_dir'])
                 # Create job file
+                job_file = os.path.join(JOB_GROUP_jobs_dir, 'job'+str(njobs))
+                print("Creating job script: "+job_file)
+                job = open(job_file, 'w')
+                job.write('#!/bin/bash\n')
+                job.write('set -x\n')
+                job.write('\n')
+                # Write environment variables
+                for name, value in job_env_dict.items():
+                    job.write('export '+name+'="'+value+'"\n')
+                job.write('\n')
+                job.write(
+                    vfg_util.python_g2g_command('grid2grid_plots.py',[])
+                    +'\n'
+                )
+                job.close()
+            elif JOB_GROUP == 'scorecard_avg_ci':
+                job_env_dict['line_type'] = loop_info[0]
+                job_env_dict['fcst_var_level'] = loop_info[1]
+                job_env_dict['obs_var_level'] = (
+                    case_type_plot_jobs_dict[case_type_job]\
+                    ['obs_var_dict']['levels'][
+                        case_type_plot_jobs_dict[case_type_job]\
+                        ['fcst_var_dict']['levels'].index(loop_info[1])
+                    ]
+                )
+                job_env_dict['vx_mask'] = loop_info[2]
+                job_env_dict['fcst_var_thresh'] = loop_info[3]
+                job_env_dict['obs_var_thresh'] = (
+                    case_type_plot_jobs_dict[case_type_job]\
+                    ['obs_var_dict']['threshs'][
+                        case_type_plot_jobs_dict[case_type_job]\
+                        ['fcst_var_dict']['threshs'].index(loop_info[3])
+                    ]
+                )
+                job_env_dict['interp_method'] = loop_info[4].split('/')[0]
+                job_env_dict['interp_points'] = loop_info[4].split('/')[1]
+                job_env_dict['metric'] = loop_info[5]
+                job_env_dict['valid_hr_list'] = "00"
+                job_env_dict['init_hr_list'] = "00"
+                job_env_dict['model_list'] = ', '.join(model_list)
+                job_env_dict['obs_list'] = ', '.join(obs_list)
+                job_env_dict['fhr_list'] = "24, 48, 72, 96, 120, 144, 168, 192, 216, 240"
+                job_env_dict['CI_METHOD'] = CI_METHOD
+                job_env_dict['AVERAGE_METHOD'] = AVERAGE_METHOD
+                # Set up output directories
+                njobs+=1
+                job_env_dict['job_id'] = 'job'+str(njobs)
+                job_DATA_dir = os.path.join(DATA, RUN, 'plot_output',
+                                            'plot_by_'+plot_by,
+                                            JOB_GROUP)
+                job_env_dict['job_DATA_dir'] = job_DATA_dir
+                vfg_util.make_dir(job_env_dict['job_DATA_dir'])
+                # Create job file
                 job_file = os.path.join(JOB_GROUP_jobs_dir,
                                         'job'+str(njobs))
                 print("Creating job script: "+job_file)
@@ -519,7 +602,7 @@ for case_type in case_type_list:
                     job.write('export '+name+'="'+value+'"\n')
                 job.write('\n')
                 job.write(
-                    vfg_util.python_g2g_command('grid2grid_plots.py',[])
+                    vfg_util.python_g2g_command('scorecard_avg_ci.py',[])
                     +'\n'
                 )
                 job.close()

--- a/ush/plots/grid2grid/verif_global_util.py
+++ b/ush/plots/grid2grid/verif_global_util.py
@@ -607,12 +607,12 @@ def initialize_job_env_dict(case_type, group,
         'machine', 'HOMEverif_global', 'FIXverif_global', 'USHverif_global', 'DATA',
         'NET', 'RUN'
     ]
-    if group in ['condense_stats', 'filter_stats', 'make_plots']:
+    if group in ['condense_stats', 'filter_stats', 'scorecard_avg_ci', 'make_plots']:
         job_env_var_list.extend(['HOMEMET', 'MET_version'])
     job_env_dict = {}
     for env_var in job_env_var_list:
         job_env_dict[env_var] = os.environ[env_var]
-    if group in ['condense_stats', 'filter_stats', 'make_plots']:
+    if group in ['condense_stats', 'filter_stats', 'scorecard_avg_ci', 'make_plots']:
         job_env_dict['plot_verbosity'] = 'DEBUG'
     job_env_dict['CASE_TYPE'] = case_type
     job_env_dict['JOB_GROUP'] = group
@@ -1818,3 +1818,599 @@ def calculate_average(logger, average_method, line_type, stat, df):
         logger.warning(f"{average_method} not recognized..."
                        +"use mean, or aggregation...returning NaN")
     return average_value
+
+def calculate_scorecard_stat(logger, model_data, stat):
+    """! Calculate the statistic from the data from the
+         read in MET .stat file(s)
+
+             Args:
+                 model_data        - Dataframe containing the model(s)
+                                     information from the MET .stat
+                                     files
+                 stat              - string of the simple statistic
+                                     name being plotted
+
+             Returns:
+                 stat_values       - Dataframe of the statistic values
+                 stat_values_array - array of the statistic values
+                 stat_plot_name    - string of the formal statistic
+                                     name being plotted
+    """
+    model_data_columns = model_data.columns.values.tolist()
+    if model_data_columns == [ 'TOTAL' ]:
+        logger.warning("Empty model_data dataframe")
+        line_type = 'NULL'
+        if (stat == 'fbar_obar' or stat == 'orate_frate'
+                or stat == 'baser_frate'):
+            stat_values = model_data.loc[:][['TOTAL']]
+            stat_values_fbar = model_data.loc[:]['TOTAL']
+            stat_values_obar = model_data.loc[:]['TOTAL']
+        else:
+            stat_values = model_data.loc[:]['TOTAL']
+    else:
+        if all(elem in model_data_columns for elem in
+               ['FBAR', 'OBAR', 'MAE']):
+            line_type = 'SL1L2'
+            fbar = model_data.loc[:]['FBAR']
+            obar = model_data.loc[:]['OBAR']
+            fobar = model_data.loc[:]['FOBAR']
+            ffbar = model_data.loc[:]['FFBAR']
+            oobar = model_data.loc[:]['OOBAR']
+        elif all(elem in model_data_columns for elem in
+                 ['FABAR', 'OABAR', 'MAE']):
+            line_type = 'SAL1L2'
+            fabar = model_data.loc[:]['FABAR']
+            oabar = model_data.loc[:]['OABAR']
+            foabar = model_data.loc[:]['FOABAR']
+            ffabar = model_data.loc[:]['FFABAR']
+            ooabar = model_data.loc[:]['OOABAR']
+        elif all(elem in model_data_columns for elem in
+                 ['UFBAR', 'VFBAR']):
+            line_type = 'VL1L2'
+            ufbar = model_data.loc[:]['UFBAR']
+            vfbar = model_data.loc[:]['VFBAR']
+            uobar = model_data.loc[:]['UOBAR']
+            vobar = model_data.loc[:]['VOBAR']
+            uvfobar = model_data.loc[:]['UVFOBAR']
+            uvffbar = model_data.loc[:]['UVFFBAR']
+            uvoobar = model_data.loc[:]['UVOOBAR']
+        elif all(elem in model_data_columns for elem in
+                 ['UFABAR', 'VFABAR']):
+            line_type = 'VAL1L2'
+            ufabar = model_data.loc[:]['UFABAR']
+            vfabar = model_data.loc[:]['VFABAR']
+            uoabar = model_data.loc[:]['UOABAR']
+            voabar = model_data.loc[:]['VOABAR']
+            uvfoabar = model_data.loc[:]['UVFOABAR']
+            uvffabar = model_data.loc[:]['UVFFABAR']
+            uvooabar = model_data.loc[:]['UVOOABAR']
+        elif all(elem in model_data_columns for elem in
+                 ['VDIFF_SPEED', 'VDIFF_DIR']):
+            line_type = 'VCNT'
+            fbar = model_data.loc[:]['FBAR']
+            obar = model_data.loc[:]['OBAR']
+            fs_rms = model_data.loc[:]['FS_RMS']
+            os_rms = model_data.loc[:]['OS_RMS']
+            msve = model_data.loc[:]['MSVE']
+            rmsve = model_data.loc[:]['RMSVE']
+            fstdev = model_data.loc[:]['FSTDEV']
+            ostdev = model_data.loc[:]['OSTDEV']
+            fdir = model_data.loc[:]['FDIR']
+            odir = model_data.loc[:]['ODIR']
+            fbar_speed = model_data.loc[:]['FBAR_SPEED']
+            obar_speed = model_data.loc[:]['OBAR_SPEED']
+            vdiff_speed = model_data.loc[:]['VDIFF_SPEED']
+            vdiff_dir =  model_data.loc[:]['VDIFF_DIR']
+            speed_err = model_data.loc[:]['SPEED_ERR']
+            dir_err = model_data.loc[:]['DIR_ERR']
+        elif all(elem in model_data_columns for elem in
+                 ['FY_OY', 'FN_ON']):
+            line_type = 'CTC'
+            total = model_data.loc[:]['TOTAL']
+            fy_oy = model_data.loc[:]['FY_OY']
+            fy_on = model_data.loc[:]['FY_ON']
+            fn_oy = model_data.loc[:]['FN_OY']
+            fn_on = model_data.loc[:]['FN_ON']
+        else:
+            logger.error("Could not recognize line type from columns")
+            exit(1)
+    if stat == 'bias':
+        stat_plot_name = 'Bias'
+        if line_type == 'SL1L2':
+            stat_values = fbar - obar
+        elif line_type == 'VL1L2':
+            stat_values = np.sqrt(uvffbar) - np.sqrt(uvoobar)
+        elif line_type == 'VCNT':
+            stat_values = fbar - obar
+        elif line_type == 'CTC':
+            stat_values = (fy_oy + fy_on)/(fy_oy + fn_oy)
+    elif stat == 'rmse':
+        stat_plot_name = 'Root Mean Square Error'
+        if line_type == 'SL1L2':
+            stat_values = np.sqrt(ffbar + oobar - 2*fobar)
+        elif line_type == 'VL1L2':
+            stat_values = np.sqrt(uvffbar + uvoobar - 2*uvfobar)
+    elif stat == 'msess':
+        stat_plot_name = "Murphy's Mean Square Error Skill Score"
+        if line_type == 'SL1L2':
+            mse = ffbar + oobar - 2*fobar
+            var_o = oobar - obar*obar
+            stat_values = 1 - mse/var_o
+        elif line_type == 'VL1L2':
+            mse = uvffbar + uvoobar - 2*uvfobar
+            var_o = uvoobar - uobar*uobar - vobar*vobar
+            stat_values = 1 - mse/var_o
+    elif stat == 'rsd':
+        stat_plot_name = 'Ratio of Standard Deviation'
+        if line_type == 'SL1L2':
+            var_f = ffbar - fbar*fbar
+            var_o = oobar - obar*obar
+            stat_values = np.sqrt(var_f)/np.sqrt(var_o)
+        elif line_type == 'VL1L2':
+            var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+            var_o = uvoobar - uobar*uobar - vobar*vobar
+            stat_values = np.sqrt(var_f)/np.sqrt(var_o)
+        elif line_type == 'VCNT':
+            stat_values = fstdev/ostdev
+    elif stat == 'rmse_md':
+        stat_plot_name = 'Root Mean Square Error from Mean Error'
+        if line_type == 'SL1L2':
+            stat_values = np.sqrt((fbar-obar)**2)
+        elif line_type == 'VL1L2':
+            stat_values = np.sqrt((ufbar - uobar)**2 + (vfbar - vobar)**2)
+    elif stat == 'rmse_pv':
+        stat_plot_name = 'Root Mean Square Error from Pattern Variation'
+        if line_type == 'SL1L2':
+            var_f = ffbar - fbar**2
+            var_o = oobar - obar**2
+            R = (fobar - (fbar*obar))/(np.sqrt(var_f*var_o))
+            stat_values = np.sqrt(var_f + var_o - 2*np.sqrt(var_f*var_o)*R)
+        elif line_type == 'VL1L2':
+            var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+            var_o = uvoobar - uobar*uobar - vobar*vobar
+            R = (uvfobar - ufbar*uobar - vfbar*vobar)/(np.sqrt(var_f*var_o))
+            stat_values = np.sqrt(var_f + var_o - 2*np.sqrt(var_f*var_o)*R)
+    elif stat == 'pcor':
+        stat_plot_name = 'Pattern Correlation'
+        if line_type == 'SL1L2':
+            var_f = ffbar - fbar*fbar
+            var_o = oobar - obar*obar
+            stat_values = (fobar - fbar*obar)/(np.sqrt(var_f*var_o))
+        elif line_type == 'VL1L2':
+            var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+            var_o = uvoobar - uobar*uobar - vobar*vobar
+            stat_values = (uvfobar - ufbar*uobar - vfbar*vobar)/(np.sqrt(
+                              var_f*var_o))
+    elif stat == 'acc':
+        stat_plot_name = 'Anomaly Correlation Coefficient'
+        if line_type == 'SAL1L2':
+            stat_values = \
+                (foabar - fabar*oabar)/(np.sqrt(
+                (ffabar - fabar*fabar)*(ooabar - oabar*oabar)))
+        elif line_type == 'VAL1L2':
+            stat_values = (uvfoabar)/(np.sqrt(uvffabar*uvooabar))
+    elif stat == 'fbar':
+        stat_plot_name = 'Forecast Averages'
+        if line_type == 'SL1L2':
+            stat_values = fbar
+        elif line_type == 'VL1L2':
+            stat_values = np.sqrt(uvffbar)
+        elif line_type == 'VCNT':
+            stat_values = fbar
+    elif stat == 'fbar_obar':
+        stat_plot_name = 'Forecast and Observation Averages'
+        if line_type == 'SL1L2':
+            stat_values = model_data.loc[:][['FBAR', 'OBAR']]
+            stat_values_fbar = model_data.loc[:]['FBAR']
+            stat_values_obar = model_data.loc[:]['OBAR']
+        elif line_type == 'VL1L2':
+            stat_values = model_data.loc[:][['UVFFBAR', 'UVOOBAR']]
+            stat_values_fbar = np.sqrt(model_data.loc[:]['UVFFBAR'])
+            stat_values_obar = np.sqrt(model_data.loc[:]['UVOOBAR'])
+        elif line_type == 'VCNT':
+            stat_values = model_data.loc[:][['FBAR', 'OBAR']]
+            stat_values_fbar = model_data.loc[:]['FBAR']
+            stat_values_obar = model_data.loc[:]['OBAR']
+    elif stat == 'speed_err':
+        stat_plot_name = (
+            'Difference in Average FCST and OBS Wind Vector Speeds'
+        )
+        if line_type == 'VCNT':
+            stat_values = speed_err
+    elif stat == 'dir_err':
+        stat_plot_name = (
+            'Difference in Average FCST and OBS Wind Vector Direction'
+        )
+        if line_type == 'VCNT':
+           stat_values = dir_err
+    elif stat == 'rmsve':
+        stat_plot_name = 'Root Mean Square Difference Vector Error'
+        if line_type == 'VCNT':
+           stat_values = rmsve
+    elif stat == 'vdiff_speed':
+        stat_plot_name = 'Difference Vector Speed'
+        if line_type == 'VCNT':
+            stat_values = vdiff_speed
+    elif stat == 'vdiff_dir':
+        stat_plot_name = 'Difference Vector Direction'
+        if line_type == 'VCNT':
+           stat_values = vdiff_dir
+    elif stat == 'fbar_obar_speed':
+        stat_plot_name = 'Average Wind Vector Speed'
+        if line_type == 'VCNT':
+            stat_values = model_data.loc[:][('FBAR_SPEED', 'OBAR_SPEED')]
+    elif stat == 'fbar_obar_dir':
+        stat_plot_name = 'Average Wind Vector Direction'
+        if line_type == 'VCNT':
+           stat_values = model_data.loc[:][('FDIR', 'ODIR')]
+    elif stat == 'fbar_speed':
+        stat_plot_name = 'Average Forecast Wind Vector Speed'
+        if line_type == 'VCNT':
+            stat_values = fbar_speed
+    elif stat == 'fbar_dir':
+        stat_plot_name = 'Average Forecast Wind Vector Direction'
+        if line_type == 'VCNT':
+            stat_values = fdir
+    elif stat == 'orate' or stat == 'baser':
+        if stat == 'orate':
+            stat_plot_name = 'Observation Rate'
+        elif stat == 'baser':
+            stat_plot_name = 'Base Rate'
+        if line_type == 'CTC':
+            stat_values = (fy_oy + fn_oy)/total
+    elif stat == 'frate':
+        stat_plot_name = 'Forecast Rate'
+        if line_type == 'CTC':
+            stat_values = (fy_oy + fy_on)/total
+    elif stat == 'orate_frate' or stat == 'baser_frate':
+        if stat == 'orate_frate':
+            stat_plot_name = 'Observation and Forecast Rates'
+        elif stat == 'baser_frate':
+            stat_plot_name = 'Base and Forecast Rates'
+        if line_type == 'CTC':
+            stat_values_fbar = (fy_oy + fy_on)/total
+            stat_values_obar = (fy_oy + fn_oy)/total
+            stat_values = pd.concat([stat_values_fbar, stat_values_obar],
+                                    axis=1)
+    elif stat == 'accuracy':
+        stat_plot_name = 'Accuracy'
+        if line_type == 'CTC':
+            stat_values = (fy_oy + fn_on)/total
+    elif stat == 'fbias':
+        stat_plot_name = 'Frequency Bias'
+        if line_type == 'CTC':
+            stat_values = (fy_oy + fy_on)/(fy_oy + fn_oy)
+    elif stat == 'pod' or stat == 'hrate':
+        if stat == 'pod':
+            stat_plot_name = 'Probability of Detection'
+        elif stat == 'hrate':
+            stat_plot_name = 'Hit Rate'
+        if line_type == 'CTC':
+            stat_values = fy_oy/(fy_oy + fn_oy)
+    elif stat == 'pofd' or stat == 'farate':
+        if stat == 'pofd':
+            stat_plot_name = 'Probability of False Detection'
+        elif stat == 'farate':
+            stat_plot_name = 'False Alarm Rate'
+        if line_type == 'CTC':
+            stat_values = fy_on/(fy_on + fn_on)
+    elif stat == 'podn':
+        stat_plot_name = 'Probability of Detection of the Non-Event'
+        if line_type == 'CTC':
+            stat_values = fn_on/(fy_on + fn_on)
+    elif stat == 'faratio':
+        stat_plot_name = 'False Alarm Ratio'
+        if line_type == 'CTC':
+            stat_values = fy_on/(fy_on + fy_oy)
+    elif stat == 'csi' or stat == 'ts':
+        if stat == 'csi':
+            stat_plot_name = 'Critical Success Index'
+        elif stat == 'ts':
+            stat_plot_name = 'Threat Score'
+        if line_type == 'CTC':
+            stat_values = fy_oy/(fy_oy + fy_on + fn_oy)
+    elif stat == 'gss' or stat == 'ets':
+        if stat == 'gss':
+            stat_plot_name = 'Gilbert Skill Score'
+        elif stat == 'ets':
+            stat_plot_name = 'Equitable Threat Score'
+        if line_type == 'CTC':
+            C = ((fy_oy + fy_on)*(fy_oy + fn_oy))/total
+            stat_values = (fy_oy - C)/(fy_oy + fy_on+ fn_oy - C)
+    elif stat == 'hk' or stat == 'tss' or stat == 'pss':
+        if stat == 'hk':
+            stat_plot_name = 'Hanssen-Kuipers Discriminant'
+        elif stat == 'tss':
+            stat_plot_name = 'True Skill Score'
+        elif stat == 'pss':
+            stat_plot_name = 'Peirce Skill Score'
+        if line_type == 'CTC':
+            stat_values = (
+                ((fy_oy*fn_on)-(fy_on*fn_oy))/((fy_oy+fn_oy)*(fy_on+fn_on))
+            )
+    elif stat == 'hss':
+        stat_plot_name = 'Heidke Skill Score'
+        if line_type == 'CTC':
+            Ca = (fy_oy+fy_on)*(fy_oy+fn_oy)
+            Cb = (fn_oy+fn_on)*(fy_on+fn_on)
+            C = (Ca + Cb)/total
+            stat_values = (fy_oy + fn_on - C)/(total - C)
+    else:
+        logger.error(stat+" is not a valid option")
+        exit(1)
+    nindex = stat_values.index.nlevels
+    if stat == 'fbar_obar' or stat == 'orate_frate' or stat == 'baser_frate':
+        if nindex == 1:
+            index0 = len(stat_values_fbar.index.get_level_values(0).unique())
+            stat_values_array_fbar = (
+                np.ma.masked_invalid(
+                    stat_values_fbar.values.reshape(index0)
+                )
+            )
+            index0 = len(stat_values_obar.index.get_level_values(0).unique())
+            stat_values_array_obar = (
+                np.ma.masked_invalid(
+                    stat_values_obar.values.reshape(index0)
+                )
+            )
+        elif nindex == 2:
+            index0 = len(stat_values_fbar.index.get_level_values(0).unique())
+            index1 = len(stat_values_fbar.index.get_level_values(1).unique())
+            stat_values_array_fbar = (
+                np.ma.masked_invalid(
+                    stat_values_fbar.values.reshape(index0,index1)
+                )
+            )
+            index0 = len(stat_values_obar.index.get_level_values(0).unique())
+            index1 = len(stat_values_obar.index.get_level_values(1).unique())
+            stat_values_array_obar = (
+                np.ma.masked_invalid(
+                    stat_values_obar.values.reshape(index0,index1)
+                )
+            )
+        elif nindex == 3:
+            index0 = len(stat_values_fbar.index.get_level_values(0).unique())
+            index1 = len(stat_values_fbar.index.get_level_values(1).unique())
+            index2 = len(stat_values_fbar.index.get_level_values(2).unique())
+            stat_values_array_fbar = (
+                np.ma.masked_invalid(
+                    stat_values_fbar.values.reshape(index0,index1,index2)
+                )
+            )
+            index0 = len(stat_values_obar.index.get_level_values(0).unique())
+            index1 = len(stat_values_obar.index.get_level_values(1).unique())
+            index2 = len(stat_values_obar.index.get_level_values(2).unique())
+            stat_values_array_obar = (
+                np.ma.masked_invalid(
+                    stat_values_obar.values.reshape(index0,index1,index2)
+                )
+            )
+        stat_values_array = np.ma.array([stat_values_array_fbar,
+                                         stat_values_array_obar])
+    else:
+        if nindex == 1:
+            index0 = len(stat_values.index.get_level_values(0).unique())
+            stat_values_array = (
+                np.ma.masked_invalid(
+                    stat_values.values.reshape(1,index0)
+                )
+            )
+        elif nindex == 2:
+            index0 = len(stat_values.index.get_level_values(0).unique())
+            index1 = len(stat_values.index.get_level_values(1).unique())
+            stat_values_array = (
+                np.ma.masked_invalid(
+                    stat_values.values.reshape(1,index0,index1)
+                )
+            )
+        elif nindex == 3:
+            index0 = len(stat_values.index.get_level_values(0).unique())
+            index1 = len(stat_values.index.get_level_values(1).unique())
+            index2 = len(stat_values.index.get_level_values(2).unique())
+            stat_values_array = (
+                np.ma.masked_invalid(
+                    stat_values.values.reshape(1,index0,index1,index2)
+                )
+            )
+    return stat_values, stat_values_array, stat_plot_name
+
+def calculate_scorecard_average(logger, average_method, stat, model_dataframe,
+                      model_stat_values):
+    """! Calculate average of dataset
+
+             Args:
+                 logger               - logging file
+                 average_method       - string of the method to
+                                        use to calculate the
+                                        average
+                 stat                 - string of the statistic the
+                                        average is being taken for
+                 model_dataframe      - dataframe of model .stat
+                                        columns
+                 model_stat_values    - array of statistic values
+
+             Returns:
+                 average_array        - array of average value(s)
+    """
+    average_array = np.empty_like(model_stat_values[:,0])
+    if average_method == 'MEAN':
+        for l in range(len(model_stat_values[:,0])):
+            average_array[l] = np.ma.mean(model_stat_values[l,:])
+    elif average_method == 'MEDIAN':
+        for l in range(len(model_stat_values[:,0])):
+            logger.info(np.ma.median(model_stat_values[l,:]))
+            average_array[l] = np.ma.median(model_stat_values[l,:])
+    elif average_method == 'AGGREGATION':
+         ndays = model_dataframe.shape[0]
+         model_dataframe_aggsum = (
+             model_dataframe.groupby('model_plot_name').agg(['sum'])
+         )
+         model_dataframe_aggsum.columns = (
+             model_dataframe_aggsum.columns.droplevel(1)
+         )
+         avg_values, avg_array, stat_plot_name = (
+             calculate_scorecard_stat(logger, model_dataframe_aggsum/ndays, stat)
+         )
+         for l in range(len(avg_array[:,0])):
+             average_array[l] = avg_array[l]
+    else:
+        logger.error("Invalid entry for MEAN_METHOD, "
+                     +"use MEAN, MEDIAN, or AGGREGATION")
+        exit(1)
+    return average_array
+
+def calculate_ci(logger, ci_method, modelB_values, modelA_values, total_days,
+                 stat, average_method, randx):
+    """! Calculate confidence intervals between two sets of data
+
+             Args:
+                 logger         - logging file
+                 ci_method      - string of the method to use to
+                                  calculate the confidence intervals
+                 modelB_values  - array of values
+                 modelA_values  - array of values
+                 total_days     - float of total number of days
+                                  being considered, sample size
+                 stat           - string of the statistic the
+                                  confidence intervals are being
+                                  calculated for
+                 average_method - string of the method to
+                                  use to calculate the
+                                  average
+                 randx          - 2D array of random numbers [0,1)
+
+             Returns:
+                 intvl          - float of the confidence interval
+    """
+    if ci_method == 'EMC':
+        modelB_modelA_diff = modelB_values - modelA_values
+        ndays = total_days - np.ma.count_masked(modelB_modelA_diff)
+        modelB_modelA_diff_mean = modelB_modelA_diff.mean()
+        modelB_modelA_std = np.sqrt(
+            ((modelB_modelA_diff - modelB_modelA_diff_mean)**2).mean()
+        )
+        if ndays >= 80:
+            intvl = 1.960*modelB_modelA_std/np.sqrt(ndays-1)
+        elif ndays >= 40 and ndays < 80:
+            intvl = 2.000*modelB_modelA_std/np.sqrt(ndays-1)
+        elif ndays >= 20 and ndays < 40:
+            intvl = 2.042*modelB_modelA_std/np.sqrt(ndays-1)
+        elif ndays < 20 and ndays > 0:
+            intvl = 2.228*modelB_modelA_std/np.sqrt(ndays-1)
+        elif ndays == 0:
+            intvl = '--'
+    elif ci_method == 'EMC_MONTE_CARLO':
+        ntest, ntests = 1, 10000
+        dates = []
+        for idx_val in modelB_values.index.values:
+            dates.append(idx_val[1])
+        ndays = len(dates)
+        rand1_data_index = pd.MultiIndex.from_product(
+            [['rand1'], np.arange(1, ntests+1, dtype=int), dates],
+            names=['model_plot_name', 'ntest', 'dates']
+        )
+        rand2_data_index = pd.MultiIndex.from_product(
+            [['rand2'], np.arange(1, ntests+1, dtype=int), dates],
+            names=['model_plot_name', 'ntest', 'dates']
+        )
+        rand1_data = pd.DataFrame(
+            np.nan, index=rand1_data_index,
+            columns=modelB_values.columns
+        )
+        rand2_data = pd.DataFrame(
+            np.nan, index=rand2_data_index,
+            columns=modelB_values.columns
+        )
+        ncolumns = len(modelB_values.columns)
+        rand1_data_values = np.empty([ntests, ndays, ncolumns])
+        rand2_data_values = np.empty([ntests, ndays, ncolumns])
+        randx_ge0_idx = np.where(randx - 0.5 >= 0)
+        randx_lt0_idx = np.where(randx - 0.5 < 0)
+        rand1_data_values[randx_ge0_idx[0], randx_ge0_idx[1],:] = (
+            modelA_values.iloc[randx_ge0_idx[1],:]
+        )
+        rand2_data_values[randx_ge0_idx[0], randx_ge0_idx[1],:] = (
+           modelB_values.iloc[randx_ge0_idx[1],:]
+        )
+        rand1_data_values[randx_lt0_idx[0], randx_lt0_idx[1],:] = (
+          modelB_values.iloc[randx_lt0_idx[1],:]
+        )
+        rand2_data_values[randx_lt0_idx[0], randx_lt0_idx[1],:] = (
+            modelA_values.iloc[randx_lt0_idx[1],:]
+        )
+        ntest = 1
+        while ntest <= ntests:
+            rand1_data.loc[('rand1', ntest)] = rand1_data_values[ntest-1,:,:]
+            rand2_data.loc[('rand2', ntest)] = rand2_data_values[ntest-1,:,:]
+            ntest+=1
+        intvl = np.nan
+        rand1_stat_values, rand1_stat_values_array, stat_plot_name = (
+            calculate_scorecard_stat(logger, rand1_data, stat)
+        )
+        rand2_stat_values, rand2_stat_values_array, stat_plot_name = (
+            calculate_scorecard_stat(logger, rand2_data, stat)
+        )
+        rand1_average_array = (
+            calculate_scorecard_average(logger, average_method, stat, rand1_data,
+                              rand1_stat_values_array[0,0,:,:])
+        )
+        rand2_average_array = (
+            calculate_scorecard_average(logger, average_method, stat, rand2_data,
+                              rand2_stat_values_array[0,0,:,:])
+        )
+        scores_diff = rand2_average_array - rand1_average_array
+        scores_diff_mean = np.sum(scores_diff)/ntests
+        scores_diff_var = np.sum((scores_diff-scores_diff_mean)**2)
+        scores_diff_std = np.sqrt(scores_diff_var/(ntests-1))
+        intvl = 1.96*scores_diff_std
+    else:
+        logger.error("Invalid entry for MAKE_CI_METHOD, "
+                     +"use EMC, EMC_MONTE_CARLO")
+        exit(1)
+    return intvl
+
+def get_lead_avg_file(stat, input_filename, fcst_lead, output_base_dir):
+    lead_avg_filename = stat + '_' + os.path.basename(input_filename) \
+                        .replace('_dump_row.stat', '')
+    # if fcst_leadX is in filename, replace it with fcst_lead_avgs
+    # and add .txt to end of filename
+    if f'fhr{fcst_lead}' in lead_avg_filename:
+        lead_avg_filename = (
+            lead_avg_filename.replace(f'fhr{fcst_lead}',
+                                      'fcst_lead_avgs')
+        )
+        lead_avg_filename += '.txt'
+
+    # if not, remove mention of forecast lead and
+    # add fcst_lead_avgs.txt to end of filename
+    elif 'fcst_lead_avgs' not in input_filename:
+        lead_avg_filename = lead_avg_filename.replace(f'fhr{fcst_lead}',
+                                                      '')
+        lead_avg_filename += '_fcst_lead_avgs.txt'
+
+    lead_avg_file = os.path.join(output_base_dir, 'data',
+                                 lead_avg_filename)
+    return lead_avg_file
+
+def get_ci_file(stat, input_filename, fcst_lead, output_base_dir, ci_method):
+    CI_filename = stat + '_' + os.path.basename(input_filename) \
+                  .replace('_dump_row.stat', '')
+    # if fcst_leadX is in filename, replace it with fcst_lead_avgs
+    # and add .txt to end of filename
+    if f'fhr{fcst_lead}' in CI_filename:
+        CI_filename = CI_filename.replace(f'fhr{fcst_lead}',
+                                          'fcst_lead_avgs')
+
+    # if not and fcst_lead_avgs isn't already in filename,
+    # remove mention of forecast lead and
+    # add fcst_lead_avgs.txt to end of filename
+    elif 'fcst_lead_avgs' not in CI_filename:
+        CI_filename = CI_filename.replace(f'fhr{fcst_lead}',
+                                          '')
+        CI_filename += '_fcst_lead_avgs'
+
+    CI_filename += '_CI_' + ci_method + '.txt'
+
+    CI_file = os.path.join(output_base_dir, 'data',
+                           CI_filename)
+    return CI_file


### PR DESCRIPTION
Integrate Python code to replace the existing computation of average and confidence interval files within the spack-stack-1.9.3 environment on GAEA.

PR test instruction:

clone https://github.com/Ho-ChunHuang-NOAA/EMC_verif-global.git to [PR working-directory]

cd [PR working-directory]

git checkout feature/scorecard_PR

cd ush

bash run_verif_global.sh (followed with series of prompt)

Send and check the scorecard html and grid2grid images on the RZDM. I will need to know the location of PR test tmp directory.  Shannon may need to assist with checking the grid2grid images.

Be aware that the current version of the grd2grid step2 make_plots step will produce numerous Pandas FutureWarning messages. These warnings have already been addressed and removed during the scorecard_avg_ci process and within plot_scorecard.py.