### PR TITLE
feature/ss193 grid2grid allow timeseries gaps

### DIFF
--- a/ush/plots/grid2grid/plot_time_series.py
+++ b/ush/plots/grid2grid/plot_time_series.py
@@ -390,8 +390,8 @@ class TimeSeries:
                             round(obar_model_num_avg, 3), '.3f'
                         )
                 ax.plot_date(
-                    np.ma.compressed(masked_plot_dates),
-                    np.ma.compressed(masked_model_num_data),
+                    masked_plot_dates,
+                    masked_model_num_data,
                     fmt=model_num_plot_settings_dict['marker'],
                     color = model_num_plot_settings_dict['color'],
                     linestyle = model_num_plot_settings_dict['linestyle'],
@@ -417,8 +417,8 @@ class TimeSeries:
                             model_plot_settings_dict['obs']
                         )
                         ax.plot_date(
-                            np.ma.compressed(obar_masked_plot_dates),
-                            np.ma.compressed(obar_masked_model_num_data),
+                            obar_masked_plot_dates,
+                            obar_masked_model_num_data,
                             fmt = obs_plot_settings_dict['marker'],
                             color = obs_plot_settings_dict['color'],
                             linestyle = obs_plot_settings_dict['linestyle'],


### PR DESCRIPTION
This PR allows gaps in time series plots where data is undefined and is based from PR #184  and draws from PR #188  changes for time series.
### **Developer Questions and Checklist**
Is this a high priority PR? Not really, but sooner the better so others can fix their own components.
Do you have any planned upcoming annual leave/PTO? Yes, Jan 8
### **Testing Instructions**
Create a test_pr directory
git clone https://github.com/ShannonShields-NOAA/EMC_verif-global.git
git checkout feature/ss193-grid2grid-allow-time-series-gaps
cd parm/config/driver_standalone_step2_plots.sh
Make sure to set the following:
export RUN_GRID2GRID_STEP2="YES"
export model_stat_dir_list="/gpfs/f6/ira-sti/world-shared/Shannon.Shields/stats /gpfs/f6/ira-sti/world-shared/Shannon.Shields/stats"
export g2g2_type_list="sfc" (We don't need to run the full set; just need a quick time series check)
export g2g2_make_scorecard="NO" (Don't need to test this)
cd into ush/
./run_verif_global.sh ../parm/config/driver_standalone_step2_plots.sh
Plots should look like the following (discontinuous with gaps):
<img width="1917" height="1015" alt="Screenshot 2026-01-02 160323" src="https://github.com/user-attachments/assets/b03b1ea4-5483-40b0-84cc-6d7f474bc091" />
<img width="1914" height="1015" alt="Screenshot 2026-01-02 160136" src="https://github.com/user-attachments/assets/c5128cd9-0b95-43ff-8e3e-fe1d093c78d5" />
<img width="1919" height="1017" alt="Screenshot 2026-01-02 155834" src="https://github.com/user-attachments/assets/5d55f327-0612-4ed8-ac89-05c444b3e806" />

