### PR TITLE
Upgrade to spack-stack 2.0.0 on C6

### DIFF
--- a/modulefiles/emc_verif_global_gaeac6.lua
+++ b/modulefiles/emc_verif_global_gaeac6.lua
@@ -2,15 +2,18 @@ help([[
 Load environment to run EMC_verif-global on Gaea-C6 using Intel
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-2.0.0/envs/ue-oneapi-2025.2.1/modules/Core")
 
-stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
-load(pathJoin("stack-oneapi", stack_oneapi_ver))
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2025.2.1"
+load(pathJoin("stack-intel-oneapi-compilers", stack_oneapi_ver))
+
+python_ver=os.getenv("python_ver") or "3.11.11"
+load(pathJoin("python", python_ver))
 
 Core_ver=os.getenv("Core_ver") or "24.11"
 load(pathJoin("Core", Core_ver))
 
-prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+prod_util_ver=os.getenv("prod_util_ver") or "2.1.2"
 load(pathJoin("prod_util", prod_util_ver))
 
 stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.32"
@@ -25,7 +28,7 @@ load(pathJoin("grads", grads_ver))
 imagemagick_ver=os.getenv("imagemagick_ver") or "7.1.1-29"
 load(pathJoin("imagemagick", imagemagick_ver))
 
-jasper_ver=os.getenv("jasper_ver") or "2.0.32"
+jasper_ver=os.getenv("jasper_ver") or "4.2.4"
 load(pathJoin("jasper", jasper_ver))
 
 udunits_ver=os.getenv("udunits_ver") or "2.2.28"
@@ -37,7 +40,7 @@ load(pathJoin("grib-util", grib_util_ver))
 wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
 load(pathJoin("wgrib2", wgrib2_ver))
 
-nco_ver=os.getenv("nco_ver") or "5.2.4"
+nco_ver=os.getenv("nco_ver") or "5.3.3"
 load(pathJoin("nco", nco_ver))
 
 met_ver=os.getenv("met_ver") or "12.0.1"
@@ -49,7 +52,7 @@ load(pathJoin("metplus", metplus_ver))
 bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 load(pathJoin("bufr", bufr_ver))
 
-cdo_ver=os.getenv("cdo_ver") or "2.4.4"
+cdo_ver=os.getenv("cdo_ver") or "2.5.2"
 load(pathJoin("cdo", cdo_ver))
 
 matplotlib_ver=os.getenv("matplotlib_ver") or "3.7.4"

--- a/parm/config/standalone_step1_stats.append
+++ b/parm/config/standalone_step1_stats.append
@@ -13,13 +13,13 @@ export KEEPDATA=YES
 ##################DO NOT EDIT BELOW THIS LINE######################
 
 # Load the needed modules for METplus
-module use /ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install/modulefiles/Core
-module load stack-oneapi
+module use /ncrc/proj/epic/spack-stack/c6/spack-stack-2.0.0/envs/ue-oneapi-2025.2.1/modules/Core
+module load stack-intel-oneapi-compilers
 module load stack-cray-mpich
-module load stack-python
+module load python/3.11.11
 module load metplus/6.0.0
 module load met/12.0.1
-module load prod_util/2.1.1
+module load prod_util/2.1.2
 module load wgrib2
 module load grib-util
 


### PR DESCRIPTION
This upgrades the module on C6 to spack-stack 2.0.0.  I have only verified that the module loads.  I have not attempted to test the system.

Refs #198 