### PR TITLE
Rename EE2 Environment Variables: Replace NET-Specific (VARgfs) with Global Naming

### DIFF
--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -34,7 +34,7 @@ export vhr_list="$(seq -s ' ' -f '%02g' ${start_cyc} ${INTERVAL_GFS:-24} ${cyc2r
 export RUN_GRID2GRID_STEP1=${RUN_GRID2GRID_STEP1:-NO}
 export RUN_GRID2OBS_STEP1=${RUN_GRID2OBS_STEP1:-NO}
 export RUN_PRECIP_STEP1=${RUN_PRECIP_STEP1:-NO}
-export HOMEverif_global=${HOMEverif_global:-${HOMEgfs}/sorc/verif-global.fd}
+export HOMEverif_global=${HOMEverif_global:-${HOMEglobal}/sorc/verif-global.fd}
 ## INPUT DATA SETTINGS
 export model_list=${model:-$PSLOT}
 export model_dir_list=${model_dir:-${NOSCRUB}/archive}


### PR DESCRIPTION
DESCRIPTION
- This PR updates multiple scripts in EMC_verif-global to adopt the EE2 global workflow naming convention. These changes ensure that EMC_verif-global is fully compatible with the global-workflow naming standards, aligning with the practices proposed in issue #4410. All NET-specific environment variables have been replaced with global equivalents, improving clarity, consistency, and maintainability across the workflow.