### PR TITLE
HOTFIX: Replace All GFS Variables with Global Variables

### DIFF
--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -256,7 +256,7 @@ export nproc=${nproc:-1}
 ## Set paths for verif_global, MET, and METplus
 export HOMEverif_global=$HOMEverif_global
 export PARMverif_global=$HOMEverif_global/parm
-export FIXverif_global=$FIXgfs/verif
+export FIXverif_global=$FIXglobal/verif
 export USHverif_global=$HOMEverif_global/ush
 export UTILverif_global=$HOMEverif_global/util
 export EXECverif_global=$HOMEverif_global/exec


### PR DESCRIPTION
- Fixes a missed update from [#216](https://github.com/NOAA-EMC/EMC_verif-global/pull/216), which was intended to replace all `gfs` variables with `global` variables. One location was overlooked; this PR corrects it.