### PR TITLE
Fix pruning of stat files for vx_masks of G003 and G002

### DIFF
--- a/ush/plots/grid2grid/verif_global_util.py
+++ b/ush/plots/grid2grid/verif_global_util.py
@@ -1049,8 +1049,12 @@ def condense_model_stat_files(logger, input_dir, output_dir, model, obs,
                                     line_type]
             additional_grep = ''
             for item in additional_grep_list:
-                additional_grep = (additional_grep
-                                   +f' | grep "{item} "')
+                if item == vx_mask:
+                    additional_grep = (additional_grep
+                                       +f' | grep -w "{item}"')
+                else:
+                    additional_grep = (additional_grep
+                                       +f' | grep "{item} "')
             all_grep_output = ''
             for model_stat_file in model_stat_files:
                 logger.info(f"Grep'ing {model_stat_file} for "

--- a/ush/plots/grid2obs/verif_global_util.py
+++ b/ush/plots/grid2obs/verif_global_util.py
@@ -1078,8 +1078,12 @@ def condense_model_stat_files(logger, input_dir, output_dir, model, obs,
                                     line_type]
             additional_grep = ''
             for item in additional_grep_list:
-                additional_grep = (additional_grep
-                                   +f' | grep "{item} "')
+                if item == vx_mask:
+                    additional_grep = (additional_grep
+                                       +f' | grep -w "{item}"')
+                else:
+                    additional_grep = (additional_grep
+                                       +f' | grep "{item} "')
             all_grep_output = ''
             for model_stat_file in model_stat_files:
                 logger.info(f"Grep'ing {model_stat_file} for "

--- a/ush/plots/precip/verif_global_util.py
+++ b/ush/plots/precip/verif_global_util.py
@@ -1053,8 +1053,12 @@ def condense_model_stat_files(logger, input_dir, output_dir, model, obs,
                                     line_type]
             additional_grep = ''
             for item in additional_grep_list:
-                additional_grep = (additional_grep
-                                   +f' | grep "{item} "')
+                if item == vx_mask:
+                    additional_grep = (additional_grep
+                                       +f' | grep -w "{item}"')
+                else:
+                    additional_grep = (additional_grep
+                                       +f' | grep "{item} "')
             all_grep_output = ''
             for model_stat_file in model_stat_files:
                 logger.info(f"Grep'ing {model_stat_file} for "

--- a/ush/plots/satellite/verif_global_util.py
+++ b/ush/plots/satellite/verif_global_util.py
@@ -1005,8 +1005,12 @@ def condense_model_stat_files(logger, input_dir, output_dir, model, obs,
                                     line_type]
             additional_grep = ''
             for item in additional_grep_list:
-                additional_grep = (additional_grep
-                                   +f' | grep "{item} "')
+                if item == vx_mask:
+                    additional_grep = (additional_grep
+                                       +f' | grep -w "{item}"')
+                else:
+                    additional_grep = (additional_grep
+                                       +f' | grep "{item} "')
             all_grep_output = ''
             for model_stat_file in model_stat_files:
                 logger.info(f"Grep'ing {model_stat_file} for "

--- a/ush/prune_stat_files.py
+++ b/ush/prune_stat_files.py
@@ -51,7 +51,7 @@ for env_var_model in env_var_model_list:
               +fcst_var_name+", line_type "+line_type+", interp "
               +os.environ['interp'])
         filter_cmd = (
-            ' | grep "'+vx_mask
+            ' | grep -w "'+vx_mask
             +'" | grep "'+fcst_var_name
             +'" | grep "'+line_type
             +'" | grep "'+os.environ['interp']+'"'
@@ -60,7 +60,7 @@ for env_var_model in env_var_model_list:
         print("Pruning "+data_dir+" files for vx_mask "+vx_mask+", variable "
               +fcst_var_name+", line_type "+line_type)
         filter_cmd = (
-            ' | grep "'+vx_mask
+            ' | grep -w "'+vx_mask
             +'" | grep "'+fcst_var_name
             +'" | grep "'+line_type+'"'
         )


### PR DESCRIPTION
This PR fixes an issue in the pruning of stat files where using `grep` with `vx_mask` values such as `G003` or `G002` incorrectly matched multiple domains, resulting in improperly pruned output files in `plot_output/plot_by_VALID/condense_stats/`. This impacts `grid2grid step 2` and `grid2obs step 2`. 

The root cause was that the `DESC` column in the stat files contains strings such as `on_G003` across all domains (e.g., g003, nh, sh, etc.). As a result, a substring match with `grep` would incorrectly match unintended items (e.g. `G003` matching `on_G003`).

This PR resolves the issue by adding the `-w` flag to `grep`, which ensures matches are performed on whole words only. This prevents false positives caused by partial substring matches and ensures that only the intended `vx_mask` entries are selected during pruning in the `condense_model_stat_files` function. It should be noted that this fix does not change the final plotting results, but it does increase the efficiency of the `grid2grid step 2` and `grid2obs step 2` jobs. 

**Example of the Fix**
Here is an example of a condensed stat file for `G002` before the fix: `/lfs/h2/emc/ens/noscrub/eric.sinsky/EMC_Verif/issue168_sample_data/verif_global.827790/grid2grid_step2/plot_output/plot_by_VALID/condense_stats/pres/condensed_stats_gfs_sl1l2_hgt_p500_g002.stat`. Note that all domains are included in `condensed_stats_gfs_sl1l2_hgt_p500_g002.stat`, whereas only statistics for `g002` should be present.

Here is an example of a condensed stat file for `G002` after the fix: `/lfs/h2/emc/ens/noscrub/eric.sinsky/EMC_Verif/issue168_sample_data/verif_global_fixed.2025296/grid2grid_step2/plot_output/plot_by_VALID/condense_stats/pres/condensed_stats_gfs_sl1l2_hgt_p500_g002.stat`. Note that only the `g002` statistics are included in `condensed_stats_gfs_sl1l2_hgt_p500_g002.stat`, as expected.

**Testing Instructions for g2g and g2o step 2 on WCOSS2**
1. `git clone --branch issue168 git@github.com:EricSinsky-NOAA/EMC_verif-global.git emc_verif_pr235_test`
2. `cd emc_verif_pr235_test/parm/config`
3.  `cp /lfs/h2/emc/ens/noscrub/eric.sinsky/EMC_Verif/emcverif_issue168/parm/config/config.step2.g2o_g2g_test ./`
4. In `config.step2.g2o_g2g_test`, change `tar_archive_dir` to a location to which you have read and write access. 
5. `cd ../../ush`
6. `./run_verif_global.sh ../parm/config/config.step2.g2o_g2g_test`

Resolves #168 