### PR TITLE
GRID2GRID_STEP2 obs name not getting set correctly

### DIFF
--- a/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
+++ b/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
@@ -461,8 +461,8 @@ for case_type in case_type_list:
             .split(' ')
         )
         obs_list = []
-        for cobs in config_obs_list:
-            idx = config_obs_list.index(cobs)
+        for idx in range(len(config_obs_list)):
+            cobs = config_obs_list[idx]
             obs_list.append(cobs.replace('self', model_list[idx]))
         for data_name in ['fcst', 'obs']:
             job_env_dict[data_name+'_var_name'] =  (


### PR DESCRIPTION
I discovered this in trying to test plotting the new ECM and GFS stats. The observations for ECM were getting set to "gfs_anl" in the job scripts when in the configuration file it was set to "self_anl", and thus no stats were found. This PR fixes this bug.

Testing

1. Clone my fork and checkout the branch
2. Copy /lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/EMC_verif-global/parm/config/config.step2 to your parm/config. In your clone you'll need to change `OUTPUTROOT` and `tar_archive_dir`.
3. Move to the ush directory and run `./run_verif_global.sh ../parm/config/config.step2`