### PR TITLE
Fix building of path for specific grid2grid_step1 truth sources

### DIFF
--- a/ush/check_config.py
+++ b/ush/check_config.py
@@ -394,7 +394,7 @@ if RUN == 'grid2grid_step1':
             expected_truth_file_format = (
                 'pgb'+os.environ[RUN_abbrev_type+'_truth_name'].split('_')[1]
                 +'.'+os.environ[RUN_abbrev_type+'_truth_name'].split('_')[0]
-                +'.{valid?fmt=%Y%m%d%H}'
+                +'.{valid?fmt=%Y%m%d%H}.grib2'
             )
             if os.environ[RUN_abbrev_type+'_truth_file_format_list'] \
                     != expected_truth_file_format:
@@ -435,8 +435,6 @@ elif RUN == 'grid2grid_step2':
                                                              'gdas_anl',
                                                              'gdas_f00',
                                                              'ecm_f00',
-                                                             'common_anl',
-                                                             'common_f00',
                                                              'model_mean']
         valid_config_var_values_dict[RUN_abbrev_type
                                      +'_gather_by_list'] = ['VALID', 'INIT',

--- a/ush/get_data_files.py
+++ b/ush/get_data_files.py
@@ -1090,7 +1090,11 @@ if RUN == 'grid2grid_step1':
                                 model_hpss_dir
                             )
                         else:
-                            model_RUN_abbrev_type_truth_dir = global_archive
+                            if RUN_abbrev_type_truth_name_short == 'gdas':
+                                RUN_abbrev_type_truth_name_short = 'gfs'
+                            model_RUN_abbrev_type_truth_dir = os.path.join(
+                                global_archive,  RUN_abbrev_type_truth_name_short
+                            )
                             model_RUN_abbrev_type_truth_file_format = (
                                 RUN_abbrev_type_truth_file_format_list[0]
                             )
@@ -1104,8 +1108,6 @@ if RUN == 'grid2grid_step1':
                                 model_RUN_abbrev_type_data_run_hpss = (
                                     model_data_run_hpss
                                 )
-                            if RUN_abbrev_type_truth_name_short == 'gdas':
-                                RUN_abbrev_type_truth_name_short = 'gfs'
                         get_model_file(
                             valid_time, valid_time,
                             RUN_abbrev_type_truth_name_lead,
@@ -1119,25 +1121,17 @@ if RUN == 'grid2grid_step1':
                         )
                         truth_file = os.path.join(
                             model_RUN_abbrev_type_truth_dir,
-                            RUN_abbrev_type_truth_name_short,
                             format_filler(
                                 model_RUN_abbrev_type_truth_file_format,
                                 valid_time, valid_time,
                                 RUN_abbrev_type_truth_name_lead
                             )
                         )
-                    elif RUN_abbrev_type_truth_name in ['common_anl',
-                                                        'common_f00',
-                                                        'model_mean']:
-                        if 'common' in RUN_abbrev_type_truth_name:
-                            mean_truth_dir = os.path.join(
-                                cwd, 'data', RUN_abbrev_type_truth_name
-                            )
-                        elif RUN_abbrev_type_truth_name == 'model_mean':
-                            mean_truth_dir = os.path.join(
-                                cwd, 'data',
-                                RUN_type+'_'+RUN_abbrev_type_truth_name
-                            )
+                    elif RUN_abbrev_type_truth_name in ['model_mean']:
+                        mean_truth_dir = os.path.join(
+                            cwd, 'data',
+                            RUN_type+'_'+RUN_abbrev_type_truth_name
+                        )
                         if not os.path.exists(mean_truth_dir):
                             os.makedirs(mean_truth_dir)
                         truth_file = os.path.join(


### PR DESCRIPTION
If a grid2grid_step1 truth source was specified other than "self" the path was not getting built correctly. Additionally, `check_config.py` was updated to check for the new GRIB2 files. Also removes some references to the common truth files that had been previously removed

Closes #240 

### Testing

1. `git clone https://github.com/malloryprow/EMC_verif-global.git`
2. `cd EMC_verif-global`; `git checkout fix_ecm_dir`
3. `cd parm/config`
4. `cp /lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/fix_ecm_dir/EMC_verif-global/parm/config/ecm.standalone_step1_stats.append .`
5. `cp /lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/fix_ecm_dir/EMC_verif-global/parm/config/ecm.run_standalone_step1_stats.py .`
6. In `ecm.standalone_step1_stats.append` you may want to change `DATAROOT`.
7. In `ecm.run_standalone_step1_stats.py`, update `user_stats_output_location`.
8. Run `python ecm.run_standalone_step1_stats.py wcoss2 grid2grid 20260320 20260320`