### PR TITLE
Fix g2g step2 failures when more than one fcyc is used 

### DIFF
--- a/ush/plots/verif_global_util.py
+++ b/ush/plots/verif_global_util.py
@@ -495,7 +495,6 @@ def initialize_job_env_dict(case_type, group,
             )
             fhr_list = [str(i) for i in fhr_range]
         job_env_dict['fhr_list'] = ', '.join(fhr_list)
-
         case_type_valid_hr_list = (
             os.environ[run_abbrev_type+'_valid_hr_list']\
              .split(', ')
@@ -516,7 +515,6 @@ def initialize_job_env_dict(case_type, group,
         else:
             case_type_valid_hr_inc = 24
         job_env_dict['valid_hr_inc'] = str(case_type_valid_hr_inc)
-
         case_type_init_hr_list = (
             os.environ[run_abbrev_type+'_init_hr_list']\
             .split(' ')

--- a/ush/plots/verif_global_util.py
+++ b/ush/plots/verif_global_util.py
@@ -495,10 +495,14 @@ def initialize_job_env_dict(case_type, group,
             )
             fhr_list = [str(i) for i in fhr_range]
         job_env_dict['fhr_list'] = ', '.join(fhr_list)
+
         case_type_valid_hr_list = (
             os.environ[run_abbrev_type+'_valid_hr_list']\
              .split(', ')
         )
+        case_type_valid_hr_list = [
+            x.replace(',', '').strip() for x in case_type_valid_hr_list
+        ]
         job_env_dict['valid_hr_start'] = (
             case_type_valid_hr_list[0].zfill(2)
         )
@@ -506,19 +510,20 @@ def initialize_job_env_dict(case_type, group,
             case_type_valid_hr_list[-1].zfill(2)
         )
         if len(case_type_valid_hr_list) > 1:
-            case_type_valid_hr_list = [
-                x.replace(',', '').strip() for x in case_type_valid_hr_list
-            ]
             case_type_valid_hr_inc = np.min(
                 np.diff(np.array(case_type_valid_hr_list, dtype=int))
             )
         else:
             case_type_valid_hr_inc = 24
         job_env_dict['valid_hr_inc'] = str(case_type_valid_hr_inc)
+
         case_type_init_hr_list = (
             os.environ[run_abbrev_type+'_init_hr_list']\
             .split(' ')
         )
+        case_type_init_hr_list = [
+            x.replace(',', '').strip() for x in case_type_init_hr_list
+        ]
         job_env_dict['init_hr_start'] = (
             case_type_init_hr_list[0].zfill(2)
         )
@@ -526,9 +531,6 @@ def initialize_job_env_dict(case_type, group,
             case_type_init_hr_list[-1].zfill(2)
         )
         if len(case_type_init_hr_list) > 1:
-            case_type_valid_hr_list = [
-                x.replace(',', '').strip() for x in case_type_valid_hr_list
-            ]
             case_type_init_hr_inc = np.min(
                 np.diff(np.array(case_type_init_hr_list, dtype=int))
             )

--- a/ush/plots/verif_global_util.py
+++ b/ush/plots/verif_global_util.py
@@ -517,7 +517,7 @@ def initialize_job_env_dict(case_type, group,
         job_env_dict['valid_hr_inc'] = str(case_type_valid_hr_inc)
         case_type_init_hr_list = (
             os.environ[run_abbrev_type+'_init_hr_list']\
-            .split(' ')
+            .split(', ')
         )
         case_type_init_hr_list = [
             x.replace(',', '').strip() for x in case_type_init_hr_list


### PR DESCRIPTION
This PR fixes an issue where the g2g step2 job would fail when calculating `case_type_init_hr_inc` due to commas not being removed. To fix this, commas are removed from `case_type_init_hr_list` before `init_hr_start` and `init_hr_end` are created. The same is done for the `valid` variables. 

This also fixes a typo where `case_type_init_hr_list` should be used instead of `case_type_valid_hr_list`. 

This PR will be left in draft until preliminary testing has completed. 

**Testing Instructions for g2g step2**
This is a test where: 
```
g2g2_[type]_fcyc_list=00 06 12 18
g2g2_[type]_vhr_list=00 06 12 18
```
1. `git clone --branch issue260 git@github.com:EricSinsky-NOAA/EMC_verif-global.git emc_verif_pr261_test`
2. `cd emc_verif_pr261_test/parm/config`
3.  cp `/lfs/h2/emc/ens/noscrub/eric.sinsky/EMC_Verif/issue260/parm/config/config.vfry.step2 ./`
4. In `config.vfry.step2`, change `queue_account` to an account of which you are a member.
5. In `config.vfry.step2`, change `tar_archive_dir` to a location to which you have read and write access. 
6. `cd ../../ush`
7. `python drive_emc_verif_global.py  ../parm/config/config.vfry.step2`

Resolves #260 