### PR TITLE
Filter for MET stats >= version 12

### DIFF
--- a/ush/plots/verif_global_util.py
+++ b/ush/plots/verif_global_util.py
@@ -1078,6 +1078,10 @@ def build_df(job_group, logger, input_dir, output_dir, model_info_dict,
                 filtered_model_df['FCST_VALID_BEG'] = (
                     filtered_model_df['FCST_VALID_BEG'].dt.strftime('%Y%m%d_%H%M%S')
                 )
+                filtered_model_df = filtered_model_df[
+                    filtered_model_df["VERSION"].str.split('.')\
+                    .str[0].str[1:].astype(int) >= 12
+                ]
                 filtered_model_df.to_csv(
                     filtered_model_stat_file, header=met_version_line_type_col_list,
                     index=None, sep=' ', mode='w'


### PR DESCRIPTION
This PR filters the stats for the MET major version currently being (version 12). This will help as global workflow users transition to the newer version of EMC_verif-global to make sure they aren't using old stats.

Closes #272 

There is no rush to test this PR.

## Set up

1. `git clone https://github.com/malloryprow/EMC_verif-global.git`
2. `cd EMC_verif-global, git checkout feature/add_version_check`
3. `cd parm/config`
4. `cp /lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/met_ver_check/EMC_verif-global/parm/config/config.vfry.testing .`
5. In your `config.vrfy.testing`, you'll need to change or may want to change
    * `queue_account` to an account you can submit jobs to
    * `DATAROOT` to a location you can write to

## Test

1. Move to the `ush` directory and run `python drive_emc_verif_global.py ../parm/config/config.vrfy.testing`
2. The stats for 20260715 and 20260720 are from the "old" EMC_verif-global version. The are using version 9.1.3. We should see these dates filtered out.