### PR TITLE
Make job resources configurable settings

### DIFF
--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -38,6 +38,10 @@ RUN_MAPSDA=NO
 name=wcoss2
 user=$USER
 queue_account=VERF-DEV
+nodes=1
+cpus=128
+memory=100GB
+walltime=04:00:00
 
 [INPUT_OUTPUT]
 #model_list:             model names

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -38,10 +38,6 @@ RUN_MAPSDA=NO
 name=wcoss2
 user=$USER
 queue_account=VERF-DEV
-nodes=1
-cpus=128
-memory=100GB
-walltime=04:00:00
 
 [INPUT_OUTPUT]
 #model_list:             model names

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -39,7 +39,7 @@ name=wcoss2
 user=$USER
 queue_account=VERF-DEV
 nodes=1
-cpus=128
+cpus_per_node=128
 memory=100GB
 walltime=04:00:00
 

--- a/scripts/exgrid2grid_step1.sh
+++ b/scripts/exgrid2grid_step1.sh
@@ -88,7 +88,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exgrid2grid_step1.sh
+++ b/scripts/exgrid2grid_step1.sh
@@ -88,7 +88,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exgrid2grid_step1.sh
+++ b/scripts/exgrid2grid_step1.sh
@@ -88,8 +88,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exgrid2grid_step2.sh
+++ b/scripts/exgrid2grid_step2.sh
@@ -108,7 +108,9 @@ for group in ${exec_procs}; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                nselect=$(cat $PBS_NODEFILE | wc -l)
+                nnp=$(($nselect * $nproc))
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exgrid2grid_step2.sh
+++ b/scripts/exgrid2grid_step2.sh
@@ -108,8 +108,6 @@ for group in ${exec_procs}; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                nselect=$(cat $PBS_NODEFILE | wc -l)
-                nnp=$(($nselect * $nproc))
                 launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/exgrid2grid_step2.sh
+++ b/scripts/exgrid2grid_step2.sh
@@ -108,7 +108,7 @@ for group in ${exec_procs}; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exgrid2obs_step1.sh
+++ b/scripts/exgrid2obs_step1.sh
@@ -88,7 +88,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exgrid2obs_step1.sh
+++ b/scripts/exgrid2obs_step1.sh
@@ -88,7 +88,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exgrid2obs_step1.sh
+++ b/scripts/exgrid2obs_step1.sh
@@ -88,8 +88,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exgrid2obs_step2.sh
+++ b/scripts/exgrid2obs_step2.sh
@@ -90,8 +90,6 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                nselect=$(cat $PBS_NODEFILE | wc -l)
-                nnp=$(($nselect * $nproc))
                 launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/exgrid2obs_step2.sh
+++ b/scripts/exgrid2obs_step2.sh
@@ -90,7 +90,7 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exgrid2obs_step2.sh
+++ b/scripts/exgrid2obs_step2.sh
@@ -90,7 +90,9 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                nselect=$(cat $PBS_NODEFILE | wc -l)
+                nnp=$(($nselect * $nproc))
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exmaps2d.sh
+++ b/scripts/exmaps2d.sh
@@ -88,7 +88,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exmaps2d.sh
+++ b/scripts/exmaps2d.sh
@@ -88,7 +88,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exmaps2d.sh
+++ b/scripts/exmaps2d.sh
@@ -88,8 +88,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exmapsda.sh
+++ b/scripts/exmapsda.sh
@@ -89,7 +89,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exmapsda.sh
+++ b/scripts/exmapsda.sh
@@ -89,7 +89,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exmapsda.sh
+++ b/scripts/exmapsda.sh
@@ -89,8 +89,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exprecip_step1.sh
+++ b/scripts/exprecip_step1.sh
@@ -88,7 +88,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exprecip_step1.sh
+++ b/scripts/exprecip_step1.sh
@@ -88,7 +88,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exprecip_step1.sh
+++ b/scripts/exprecip_step1.sh
@@ -88,8 +88,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exprecip_step2.sh
+++ b/scripts/exprecip_step2.sh
@@ -89,7 +89,9 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                nselect=$(cat $PBS_NODEFILE | wc -l)
+                nnp=$(($nselect * $nproc))
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exprecip_step2.sh
+++ b/scripts/exprecip_step2.sh
@@ -89,7 +89,7 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exprecip_step2.sh
+++ b/scripts/exprecip_step2.sh
@@ -89,8 +89,6 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                nselect=$(cat $PBS_NODEFILE | wc -l)
-                nnp=$(($nselect * $nproc))
                 launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/exsatellite_step1.sh
+++ b/scripts/exsatellite_step1.sh
@@ -88,7 +88,9 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            nselect=$(cat $PBS_NODEFILE | wc -l)
+            nnp=$(($nselect * $nproc))
+            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exsatellite_step1.sh
+++ b/scripts/exsatellite_step1.sh
@@ -88,7 +88,7 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"
         fi

--- a/scripts/exsatellite_step1.sh
+++ b/scripts/exsatellite_step1.sh
@@ -88,8 +88,6 @@ if [ $MPMD = YES ]; then
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
             export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-            nselect=$(cat $PBS_NODEFILE | wc -l)
-            nnp=$(($nselect * $nproc))
             launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
         else
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/exsatellite_step2.sh
+++ b/scripts/exsatellite_step2.sh
@@ -90,8 +90,6 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                nselect=$(cat $PBS_NODEFILE | wc -l)
-                nnp=$(($nselect * $nproc))
                 launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/exsatellite_step2.sh
+++ b/scripts/exsatellite_step2.sh
@@ -90,7 +90,7 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nproc} -ppn ${ncpus_per_node} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/scripts/exsatellite_step2.sh
+++ b/scripts/exsatellite_step2.sh
@@ -90,7 +90,9 @@ for group in condense_stats filter_stats make_plots; do
             export MP_CMDFILE=${poe_script}
             if [ $machine = WCOSS2 ]; then
                 export LD_LIBRARY_PATH=/apps/dev/pmi-fix:$LD_LIBRARY_PATH
-                launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                nselect=$(cat $PBS_NODEFILE | wc -l)
+                nnp=$(($nselect * $nproc))
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
             else
                 launcher="srun --export=ALL --multi-prog"
             fi

--- a/ush/create_job_scripts.py
+++ b/ush/create_job_scripts.py
@@ -656,7 +656,7 @@ DATA = os.environ['DATA']
 RUN = os.environ['RUN']
 machine = os.environ['machine']
 MPMD = os.environ['MPMD']
-nproc = int(os.environ['nproc'])
+ncpus_per_node = int(os.environ['ncpus_per_node'])
 start_date = os.environ['start_date']
 end_date = os.environ['end_date']
 RUN_abbrev = os.environ['RUN_abbrev']
@@ -718,7 +718,7 @@ if MPMD == 'YES':
     while njob <= njob_files:
         job = 'job'+str(njob)
         if machine in ['HERA', 'URSA', 'ORION', 'HERCULES', 'GAEAC6']:
-            if iproc >= nproc:
+            if iproc >= ncpus_per_node:
                 poe_file.close()
                 iproc = 0
                 node+=1
@@ -743,7 +743,7 @@ if MPMD == 'YES':
     # poe script for remaining processors
     poe_file = open(poe_filename, 'a')
     iproc+=1
-    while iproc <= nproc:
+    while iproc <= ncpus_per_node:
         if machine in ['HERA', 'URSA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(
                 str(iproc-1)+' /bin/echo '+str(iproc)+'\n'

--- a/ush/drive_emc_verif_global.py
+++ b/ush/drive_emc_verif_global.py
@@ -236,7 +236,7 @@ def create_job_script(
     sh.write(f"export PARTITION_BATCH={partition}\n")
     sh.write(f"export PARTITION_DTN={partition_dtn}\n")
     sh.write(f"export CLUSTERS_DTN={clusters_dtn}\n")
-    sh.write(f"export nproc={ncpus}\n")
+    sh.write(f"export ncpus_per_node={ncpus}\n")
     sh.write(f"export MPMD=YES\n")
 
     # --- Set verif-global path ---
@@ -342,7 +342,7 @@ def create_job_script(
         sh.write("\n")
         sh.write("#Set WCOSS2 resources\n")
         sh.write("export nselect=$(cat $PBS_NODEFILE | wc -l)\n")
-        sh.write("export nnp=$(($nselect * $nproc))\n")
+        sh.write("export nproc=$(($nselect * $ncpus_per_node))\n")
 
     # --- Write configuration settings ---
     sh.write("\n")

--- a/ush/drive_emc_verif_global.py
+++ b/ush/drive_emc_verif_global.py
@@ -324,7 +324,7 @@ def create_job_script(
         +'/ghrsst/L4/GLOB/OSPO/Geo_Polar_Blended"\n'
     )
 
-    # --- Set fix files ---
+    # --- Set MET/METplus versions ---
     if "STEP1" in case or "MAPS" in case:
         sh.write("\n")
         sh.write("# Set MET and METplus versions\n")
@@ -336,6 +336,13 @@ def create_job_script(
         sh.write("\n")
         sh.write("# Set PYTHONPATH\n")
         sh.write("export PYTHONPATH=${PYTHONPATH}:${USHverif_global}/plots\n")
+
+    # --- Set resources ---
+    if machine == 'WCOSS2':
+        sh.write("\n")
+        sh.write("#Set WCOSS2 resources\n")
+        sh.write("export nselect=$(cat $PBS_NODEFILE | wc -l)\n")
+        sh.write("export nnp=$(($nselect * $nproc))\n")
 
     # --- Write configuration settings ---
     sh.write("\n")

--- a/ush/drive_emc_verif_global.py
+++ b/ush/drive_emc_verif_global.py
@@ -105,7 +105,7 @@ def create_job_script(
     # Set machine specifics
     account = user_config["MACHINE"]["queue_account"]
     if machine_name == 'GAEAC6':
-        max_ncpus = "192"
+        max_ncpus_per_node = "192"
         partition = "batch"
         clusters = "c6"
         queue = "normal"
@@ -131,7 +131,7 @@ def create_job_script(
             "/gpfs/f6/drsa-precip3/world-shared/Ho-Chun.Huang/obs_archive"
         )
     elif machine_name == 'URSA':
-        max_ncpus = "192"
+        max_ncpus_per_node = "192"
         queue = "batch"
         queueserv = "u1-service"
         partition = "u1-compute"
@@ -156,7 +156,7 @@ def create_job_script(
             "/scratch4/NCEPDEV/naqfc/Ho-Chun.Huang/noscrub/obs_archive"
         )
     elif machine_name == 'WCOSS2':
-        max_ncpus = "128"
+        max_ncpus_per_node = "128"
         queue = "dev"
         queueserv = "dev_transfer"
         partition = ""
@@ -182,12 +182,13 @@ def create_job_script(
         )
 
     nnodes = user_config["MACHINE"]["nodes"]
-    ncpus = user_config["MACHINE"]["cpus"]
+    ncpus_per_node = user_config["MACHINE"]["cpus_per_node"]
     memory = user_config["MACHINE"]["memory"]
     walltime = user_config["MACHINE"]["walltime"]
-    if int(ncpus) > int(max_ncpus):
+    if int(ncpus_per_node) > int(max_ncpus_per_node):
         error_and_exit(
-            f"Requested cpus ({ncpus}) greater than {machine_name} max ({max_ncpus})"
+            f"Requested cpus ({ncpus_per_node}) greater than "
+            +f"{machine_name} max ({max_ncpus_per_node})"
         )
     sh = open(jobfile, "w")
     submission_command = None
@@ -199,7 +200,7 @@ def create_job_script(
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
         sh.write(f"#SBATCH --ntasks={nnodes}\n")
-        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
+        sh.write(f"#SBATCH --cpus-per-task={ncpus_per_node}\n")
         sh.write(f"#SBATCH --clusters={clusters}\n")
         sh.write(f"#SBATCH --partition={partition}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
@@ -210,14 +211,14 @@ def create_job_script(
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
         sh.write(f"#SBATCH --ntasks={nnodes}\n")
-        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
+        sh.write(f"#SBATCH --cpus-per-task={ncpus_per_node}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
         sh.write(f"#SBATCH --get-user-env\n")
         submission_command = f"sbatch {jobfile}"
     elif machine_name == "WCOSS2":
         sh.write(f"#PBS -o {logfile}\n")
         sh.write(f"#PBS -e {logfile}\n")
-        sh.write(f"#PBS -l place=vscatter:exclhost,select={nnodes}:ncpus={ncpus}:ompthreads=1:mem={memory}\n")
+        sh.write(f"#PBS -l place=vscatter:exclhost,select={nnodes}:ncpus={ncpus_per_node}:ompthreads=1:mem={memory}\n")
         sh.write(f"#PBS -N {jobname}\n")
         sh.write(f"#PBS -q {queue}\n")
         sh.write(f"#PBS -A {account}\n")
@@ -236,7 +237,7 @@ def create_job_script(
     sh.write(f"export PARTITION_BATCH={partition}\n")
     sh.write(f"export PARTITION_DTN={partition_dtn}\n")
     sh.write(f"export CLUSTERS_DTN={clusters_dtn}\n")
-    sh.write(f"export ncpus_per_node={ncpus}\n")
+    sh.write(f"export ncpus_per_node={ncpus_per_node}\n")
     sh.write(f"export MPMD=YES\n")
 
     # --- Set verif-global path ---

--- a/ush/drive_emc_verif_global.py
+++ b/ush/drive_emc_verif_global.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 ########################################################################
 
 def error_and_exit(message):
-    print(f"ERROR: {message}. EXITING!")
+    print(f"{message}. EXITING!")
     sys.exit(1)
 
 def check_machine(config_machine):
@@ -102,10 +102,16 @@ def create_job_script(
         home_verif_global_path, "scripts",
         f"ex{case.lower()}.sh"
     )
+    if "STEP1" in case:
+        walltime = "04:00:00"
+        memory = "25GB"
+    else:
+        walltime = "06:00:00"
+        memory = "100GB"
     # Set machine specifics
     account = user_config["MACHINE"]["queue_account"]
     if machine_name == 'GAEAC6':
-        max_ncpus = "192"
+        nproc = "192"
         partition = "batch"
         clusters = "c6"
         queue = "normal"
@@ -131,7 +137,7 @@ def create_job_script(
             "/gpfs/f6/drsa-precip3/world-shared/Ho-Chun.Huang/obs_archive"
         )
     elif machine_name == 'URSA':
-        max_ncpus = "192"
+        nproc = "192"
         queue = "batch"
         queueserv = "u1-service"
         partition = "u1-compute"
@@ -156,7 +162,7 @@ def create_job_script(
             "/scratch4/NCEPDEV/naqfc/Ho-Chun.Huang/noscrub/obs_archive"
         )
     elif machine_name == 'WCOSS2':
-        max_ncpus = "128"
+        nproc = "128"
         queue = "dev"
         queueserv = "dev_transfer"
         partition = ""
@@ -181,14 +187,23 @@ def create_job_script(
             "/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/verif_global_obs_archive"
         )
 
-    nnodes = user_config["MACHINE"]["nodes"]
-    ncpus = user_config["MACHINE"]["cpus"]
-    memory = user_config["MACHINE"]["memory"]
-    walltime = user_config["MACHINE"]["walltime"]
-    if int(ncpus) > int(max_ncpus):
-        error_and_exit(
-            f"Requested cpus ({ncpus}) greater than {machine_name} max ({max_ncpus})"
-        )
+    if "STEP1" in case:
+        delta = timedelta(days=1)
+        ndate = 0
+        current_date = start_date
+        while current_date <= end_date:
+            ndate+=1
+            current_date += delta
+        if "GRID2GRID" in case:
+            nveriftype = 3
+        if "GRID2OBS" in case:
+            nveriftype = 2
+        if "PRECIP" in case:
+            nveriftype = 1
+        if "SATELLITE" in case:
+            nveriftype = 1
+        nproc = ndate * nveriftype
+
     sh = open(jobfile, "w")
     submission_command = None
     # --- Write the machine-specific part ---
@@ -198,8 +213,8 @@ def create_job_script(
         sh.write(f"#SBATCH --job-name={jobname}\n")
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
-        sh.write(f"#SBATCH --ntasks={nnodes}\n")
-        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
+        sh.write(f"#SBATCH --ntasks=1\n")
+        sh.write(f"#SBATCH --cpus-per-task={nproc}\n")
         sh.write(f"#SBATCH --clusters={clusters}\n")
         sh.write(f"#SBATCH --partition={partition}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
@@ -209,15 +224,15 @@ def create_job_script(
         sh.write(f"#SBATCH --job-name={jobname}\n")
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
-        sh.write(f"#SBATCH --ntasks={nnodes}\n")
-        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
+        sh.write(f"#SBATCH --ntasks=1\n")
+        sh.write(f"#SBATCH --cpus-per-task={nproc}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
         sh.write(f"#SBATCH --get-user-env\n")
         submission_command = f"sbatch {jobfile}"
     elif machine_name == "WCOSS2":
         sh.write(f"#PBS -o {logfile}\n")
         sh.write(f"#PBS -e {logfile}\n")
-        sh.write(f"#PBS -l place=vscatter:exclhost,select={nnodes}:ncpus={ncpus}:ompthreads=1:mem={memory}\n")
+        sh.write(f"#PBS -l place=shared,select=1:ncpus={nproc}:mem={memory}\n")
         sh.write(f"#PBS -N {jobname}\n")
         sh.write(f"#PBS -q {queue}\n")
         sh.write(f"#PBS -A {account}\n")
@@ -236,7 +251,7 @@ def create_job_script(
     sh.write(f"export PARTITION_BATCH={partition}\n")
     sh.write(f"export PARTITION_DTN={partition_dtn}\n")
     sh.write(f"export CLUSTERS_DTN={clusters_dtn}\n")
-    sh.write(f"export nproc={ncpus}\n")
+    sh.write(f"export nproc={nproc}\n")
     sh.write(f"export MPMD=YES\n")
 
     # --- Set verif-global path ---
@@ -400,7 +415,7 @@ if len(sys.argv) != 2:
 config_path = os.path.abspath(sys.argv[1])
 if not os.path.exists(config_path):
     error_and_exit(
-        f"{config_path} does not exist. EXITING"
+        f"ERROR: {config_path} does not exist. EXITING"
     )
 print(f"Parsing {config_path}\n")
 config = configparser.ConfigParser(interpolation=None)

--- a/ush/drive_emc_verif_global.py
+++ b/ush/drive_emc_verif_global.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 ########################################################################
 
 def error_and_exit(message):
-    print(f"{message}. EXITING!")
+    print(f"ERROR: {message}. EXITING!")
     sys.exit(1)
 
 def check_machine(config_machine):
@@ -102,16 +102,10 @@ def create_job_script(
         home_verif_global_path, "scripts",
         f"ex{case.lower()}.sh"
     )
-    if "STEP1" in case:
-        walltime = "04:00:00"
-        memory = "25GB"
-    else:
-        walltime = "06:00:00"
-        memory = "100GB"
     # Set machine specifics
     account = user_config["MACHINE"]["queue_account"]
     if machine_name == 'GAEAC6':
-        nproc = "192"
+        max_ncpus = "192"
         partition = "batch"
         clusters = "c6"
         queue = "normal"
@@ -137,7 +131,7 @@ def create_job_script(
             "/gpfs/f6/drsa-precip3/world-shared/Ho-Chun.Huang/obs_archive"
         )
     elif machine_name == 'URSA':
-        nproc = "192"
+        max_ncpus = "192"
         queue = "batch"
         queueserv = "u1-service"
         partition = "u1-compute"
@@ -162,7 +156,7 @@ def create_job_script(
             "/scratch4/NCEPDEV/naqfc/Ho-Chun.Huang/noscrub/obs_archive"
         )
     elif machine_name == 'WCOSS2':
-        nproc = "128"
+        max_ncpus = "128"
         queue = "dev"
         queueserv = "dev_transfer"
         partition = ""
@@ -187,23 +181,14 @@ def create_job_script(
             "/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/verif_global_obs_archive"
         )
 
-    if "STEP1" in case:
-        delta = timedelta(days=1)
-        ndate = 0
-        current_date = start_date
-        while current_date <= end_date:
-            ndate+=1
-            current_date += delta
-        if "GRID2GRID" in case:
-            nveriftype = 3
-        if "GRID2OBS" in case:
-            nveriftype = 2
-        if "PRECIP" in case:
-            nveriftype = 1
-        if "SATELLITE" in case:
-            nveriftype = 1
-        nproc = ndate * nveriftype
-
+    nnodes = user_config["MACHINE"]["nodes"]
+    ncpus = user_config["MACHINE"]["cpus"]
+    memory = user_config["MACHINE"]["memory"]
+    walltime = user_config["MACHINE"]["walltime"]
+    if int(ncpus) > int(max_ncpus):
+        error_and_exit(
+            f"Requested cpus ({ncpus}) greater than {machine_name} max ({max_ncpus})"
+        )
     sh = open(jobfile, "w")
     submission_command = None
     # --- Write the machine-specific part ---
@@ -213,8 +198,8 @@ def create_job_script(
         sh.write(f"#SBATCH --job-name={jobname}\n")
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
-        sh.write(f"#SBATCH --ntasks=1\n")
-        sh.write(f"#SBATCH --cpus-per-task={nproc}\n")
+        sh.write(f"#SBATCH --ntasks={nnodes}\n")
+        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
         sh.write(f"#SBATCH --clusters={clusters}\n")
         sh.write(f"#SBATCH --partition={partition}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
@@ -224,15 +209,15 @@ def create_job_script(
         sh.write(f"#SBATCH --job-name={jobname}\n")
         sh.write(f"#SBATCH --output={logfile}\n")
         sh.write(f"#SBATCH --time={walltime}\n")
-        sh.write(f"#SBATCH --ntasks=1\n")
-        sh.write(f"#SBATCH --cpus-per-task={nproc}\n")
+        sh.write(f"#SBATCH --ntasks={nnodes}\n")
+        sh.write(f"#SBATCH --cpus-per-task={ncpus}\n")
         sh.write(f"#SBATCH --qos={queue}\n")
         sh.write(f"#SBATCH --get-user-env\n")
         submission_command = f"sbatch {jobfile}"
     elif machine_name == "WCOSS2":
         sh.write(f"#PBS -o {logfile}\n")
         sh.write(f"#PBS -e {logfile}\n")
-        sh.write(f"#PBS -l place=shared,select=1:ncpus={nproc}:mem={memory}\n")
+        sh.write(f"#PBS -l place=vscatter:exclhost,select={nnodes}:ncpus={ncpus}:ompthreads=1:mem={memory}\n")
         sh.write(f"#PBS -N {jobname}\n")
         sh.write(f"#PBS -q {queue}\n")
         sh.write(f"#PBS -A {account}\n")
@@ -251,7 +236,7 @@ def create_job_script(
     sh.write(f"export PARTITION_BATCH={partition}\n")
     sh.write(f"export PARTITION_DTN={partition_dtn}\n")
     sh.write(f"export CLUSTERS_DTN={clusters_dtn}\n")
-    sh.write(f"export nproc={nproc}\n")
+    sh.write(f"export nproc={ncpus}\n")
     sh.write(f"export MPMD=YES\n")
 
     # --- Set verif-global path ---
@@ -415,7 +400,7 @@ if len(sys.argv) != 2:
 config_path = os.path.abspath(sys.argv[1])
 if not os.path.exists(config_path):
     error_and_exit(
-        f"ERROR: {config_path} does not exist. EXITING"
+        f"{config_path} does not exist. EXITING"
     )
 print(f"Parsing {config_path}\n")
 config = configparser.ConfigParser(interpolation=None)

--- a/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
+++ b/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
@@ -28,7 +28,7 @@ RUN_CASE = (RUN.split('_')[0])
 JOB_GROUP = os.environ['JOB_GROUP']
 machine = os.environ['machine']
 MPMD = os.environ['MPMD']
-nproc = int(os.environ['nproc'])
+ncpus_per_node = int(os.environ['ncpus_per_node'])
 start_date = os.environ['start_date']
 end_date = os.environ['end_date']
 plot_by = os.environ['plot_by']
@@ -757,7 +757,7 @@ if MPMD == 'YES':
     while njob <= njob_files:
         job = 'job'+str(njob)
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
-            if iproc >= nproc:
+            if iproc >= ncpus_per_node:
                 poe_file.close()
                 iproc = 0
                 node+=1
@@ -789,8 +789,8 @@ if MPMD == 'YES':
             f"cat {poe_filename} | wc -l",
             shell=True, capture_output=True, encoding="utf8"
         ).stdout.replace('\n', '')
-        nnp = int(nselect) * int(nproc)
-    while iproc <= nproc:
+        nproc = int(nselect) * int(ncpus_per_node)
+    while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(
                 str(iproc-1)+' /bin/echo '+str(iproc)+'\n'

--- a/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
+++ b/ush/plots/grid2grid/step2_grid2grid_create_job_scripts.py
@@ -784,12 +784,6 @@ if MPMD == 'YES':
                                 f"poe_jobs{str(node)}")
     poe_file = open(poe_filename, 'a')
     iproc+=1
-    if machine == 'WCOSS2':
-        nselect = subprocess.run(
-            f"cat {poe_filename} | wc -l",
-            shell=True, capture_output=True, encoding="utf8"
-        ).stdout.replace('\n', '')
-        nproc = int(nselect) * int(ncpus_per_node)
     while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(

--- a/ush/plots/grid2obs/step2_grid2obs_create_job_scripts.py
+++ b/ush/plots/grid2obs/step2_grid2obs_create_job_scripts.py
@@ -637,12 +637,6 @@ if MPMD == 'YES':
                                 f"poe_jobs{str(node)}")
     poe_file = open(poe_filename, 'a')
     iproc+=1
-    if machine == 'WCOSS2':
-        nselect = subprocess.run(
-            f"cat {poe_filename} | wc -l",
-            shell=True, capture_output=True, encoding="utf8"
-        ).stdout.replace('\n', '')
-        nproc = int(nselect) * int(ncpus_per_node)
     while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(

--- a/ush/plots/grid2obs/step2_grid2obs_create_job_scripts.py
+++ b/ush/plots/grid2obs/step2_grid2obs_create_job_scripts.py
@@ -28,7 +28,7 @@ RUN_CASE = (RUN.split('_')[0])
 JOB_GROUP = os.environ['JOB_GROUP']
 machine = os.environ['machine']
 MPMD = os.environ['MPMD']
-nproc = int(os.environ['nproc'])
+ncpus_per_node = int(os.environ['ncpus_per_node'])
 start_date = os.environ['start_date']
 end_date = os.environ['end_date']
 plot_by = os.environ['plot_by']
@@ -610,7 +610,7 @@ if MPMD == 'YES':
     while njob <= njob_files:
         job = 'job'+str(njob)
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
-            if iproc >= nproc:
+            if iproc >= ncpus_per_node:
                 poe_file.close()
                 iproc = 0
                 node+=1
@@ -642,8 +642,8 @@ if MPMD == 'YES':
             f"cat {poe_filename} | wc -l",
             shell=True, capture_output=True, encoding="utf8"
         ).stdout.replace('\n', '')
-        nnp = int(nselect) * int(nproc)
-    while iproc <= nproc:
+        nproc = int(nselect) * int(ncpus_per_node)
+    while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(
                 str(iproc-1)+' /bin/echo '+str(iproc)+'\n'

--- a/ush/plots/precip/step2_precip_create_job_scripts.py
+++ b/ush/plots/precip/step2_precip_create_job_scripts.py
@@ -28,7 +28,7 @@ RUN_CASE = (os.environ['RUN'].split('_')[0])
 JOB_GROUP = os.environ['JOB_GROUP']
 machine = os.environ['machine']
 MPMD = os.environ['MPMD']
-nproc = int(os.environ['nproc'])
+ncpus_per_node = int(os.environ['ncpus_per_node'])
 start_date = os.environ['start_date']
 end_date = os.environ['end_date']
 plot_by = os.environ['plot_by']
@@ -331,7 +331,7 @@ if MPMD == 'YES':
     while njob <= njob_files:
         job = 'job'+str(njob)
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
-            if iproc >= nproc:
+            if iproc >= ncpus_per_node:
                 poe_file.close()
                 iproc = 0
                 node+=1
@@ -362,8 +362,8 @@ if MPMD == 'YES':
             f"cat {poe_filename} | wc -l",
             shell=True, capture_output=True, encoding="utf8"
         ).stdout.replace('\n', '')
-        nnp = int(nselect) * int(nproc)
-    while iproc <= nproc:
+        nproc = int(nselect) * int(ncpus_per_node)
+    while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(
                 '/bin/echo '+str(iproc)+'\n'

--- a/ush/plots/precip/step2_precip_create_job_scripts.py
+++ b/ush/plots/precip/step2_precip_create_job_scripts.py
@@ -357,12 +357,6 @@ if MPMD == 'YES':
                                 f"poe_jobs{str(node)}")
     poe_file = open(poe_filename, 'a')
     iproc+=1
-    if machine == 'WCOSS2':
-        nselect = subprocess.run(
-            f"cat {poe_filename} | wc -l",
-            shell=True, capture_output=True, encoding="utf8"
-        ).stdout.replace('\n', '')
-        nproc = int(nselect) * int(ncpus_per_node)
     while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(

--- a/ush/plots/satellite/step2_satellite_create_job_scripts.py
+++ b/ush/plots/satellite/step2_satellite_create_job_scripts.py
@@ -449,12 +449,6 @@ if MPMD == 'YES':
                                 f"poe_jobs{str(node)}")
     poe_file = open(poe_filename, 'a')
     iproc+=1
-    if machine == 'WCOSS2':
-        nselect = subprocess.run(
-            f"cat {poe_filename} | wc -l",
-            shell=True, capture_output=True, encoding="utf8"
-        ).stdout.replace('\n', '')
-        nproc = int(nselect) * int(ncpus_per_node)
     while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(

--- a/ush/plots/satellite/step2_satellite_create_job_scripts.py
+++ b/ush/plots/satellite/step2_satellite_create_job_scripts.py
@@ -28,7 +28,7 @@ RUN_CASE = (RUN.split('_')[0])
 JOB_GROUP = os.environ['JOB_GROUP']
 machine = os.environ['machine']
 MPMD = os.environ['MPMD']
-nproc = int(os.environ['nproc'])
+ncpus_per_node = int(os.environ['ncpus_per_node'])
 start_date = os.environ['start_date']
 end_date = os.environ['end_date']
 plot_by = os.environ['plot_by']
@@ -422,7 +422,7 @@ if MPMD == 'YES':
     while njob <= njob_files:
         job = 'job'+str(njob)
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
-            if iproc >= nproc:
+            if iproc >= ncpus_per_node:
                 poe_file.close()
                 iproc = 0
                 node+=1
@@ -454,8 +454,8 @@ if MPMD == 'YES':
             f"cat {poe_filename} | wc -l",
             shell=True, capture_output=True, encoding="utf8"
         ).stdout.replace('\n', '')
-        nnp = int(nselect) * int(nproc)
-    while iproc <= nproc:
+        nproc = int(nselect) * int(ncpus_per_node)
+    while iproc <= ncpus_per_node:
         if machine in ['HERA', 'ORION', 'HERCULES', 'GAEAC6']:
             poe_file.write(
                 str(iproc-1)+' /bin/echo '+str(iproc)+'\n'

--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -246,6 +246,10 @@ export PARTITION_DTN=${PARTITION_DTN:-""}
 ## Run settings for machines
 export MPMD="YES"
 export ncpus_per_node=${nproc:-1}
+if [ $machine = "WCOSS2" ]; then
+   export nselect=$(cat $PBS_NODEFILE | wc -l)
+   export nproc=$(($nselect * $ncpus_per_node)) 
+fi
 
 ## Set paths for verif_global, MET, and METplus
 export HOMEverif_global=$HOMEverif_global

--- a/ush/run_verif_global_in_global_workflow.sh
+++ b/ush/run_verif_global_in_global_workflow.sh
@@ -245,7 +245,7 @@ export PARTITION_DTN=${PARTITION_DTN:-""}
 
 ## Run settings for machines
 export MPMD="YES"
-export nproc=${nproc:-1}
+export ncpus_per_node=${nproc:-1}
 
 ## Set paths for verif_global, MET, and METplus
 export HOMEverif_global=$HOMEverif_global


### PR DESCRIPTION
This PR make job resource settings (walltime, memory, nodes/chunks, and cpus) configurable settings. This allows users to easily set more or less resources based on their jobs. This has been tested on WCOSS2 and not RDHPCS.

Closes #277 

## Set up
1. `git clone https://github.com/malloryprow/EMC_verif-global.git`
2. `cd EMC_verif-global`
3. `git checkout feature/config_resources`
4. `cd parm/config`
5. `cp /lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/config_resources/EMC_verif-global/parm/config/config.vrfy.step2 .`
6. In your `config.vrfy.step2` you'll need to change or may want to change
    * `queue_account` to an account you can submit jobs to
    * `DATAROOT` to a location you can write to
    * `tar_archive_dir` to a location you can write to

## Test
1. Move to the ush directory and run `python drive_emc_verif_global.py ../parm/config/config.vrfy.step2`